### PR TITLE
Depend on num_trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num = "0.2.1"
+num-traits = "0.2"
 log = "0.4.8"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,5 +1,5 @@
 use crate::WindowFunction;
-use num::traits::Float;
+use num_traits::Float;
 
 /// Calculate the scalar produt of an input wave and the selected sinc filter
 pub fn get_sinc_interpolated<T: Float>(

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -1,4 +1,4 @@
-use num::traits::Float;
+use num_traits::Float;
 
 /// Perform cubic polynomial interpolation to get value at x.
 /// Input points are assumed to be at x = -1, 0, 1, 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ mod interpolation;
 
 use crate::helpers::*;
 use crate::interpolation::*;
-use num::traits::Float;
+use num_traits::Float;
 use std::error;
 use std::fmt;
 


### PR DESCRIPTION
Hi!

Nice library! I just started to use it in the emulation path of my Nintendo 64 game.  https://github.com/JoNil/loka-n64

We can use num_trait instead of num to get a smaller dependency tree :)

It would be nice to be able to work on interleaved data. But i can't think of a good interface.

I first tried to use the resampler in the sample crate. That one is generic over the layout but that also makes it horrible to use 😆 That's why i ended up here 😀

Cheers

Jonathan
