### PR TITLE
Update dependencies to latest minor/patch release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ edition = "2018"
 
 [dependencies]
 num = "0.2"
-log = "0.4.8"
-realfft = "0.2.0"
+log = "0.4.11"
+realfft = "0.2.1"
 
 [dev-dependencies] 
 env_logger = "0.7.1"
-criterion = "0.3"
+criterion = "0.3.3"
 
 [[bench]]
 name = "resamplers"


### PR DESCRIPTION
- log: 0.4.8 → 0.4.11
- realfft: 0.2.0 → 0.2.1
- criterion: 0.3 → 0.3.3

Unfortunately, upgrading to num 0.3 seems impossible, as realfft
depends (through rustfft) on 0.2.  I might look at sending a patch there.