### PR TITLE
Use num-* libraries instead of num itself

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num = "0.2"
+num-complex = "0.2"
+num-integer = "0.1.39"
+num-traits = "0.2"
 log = "0.4.8"
 realfft = "0.2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use crate::windows::WindowFunction;
 
 use crate::interpolation::*;
 use crate::sinc::make_sincs;
-use num::traits::Float;
+use num_traits::Float;
 use std::error;
 use std::fmt;
 

--- a/src/sinc.rs
+++ b/src/sinc.rs
@@ -1,5 +1,5 @@
 use crate::windows::{make_window, WindowFunction};
-use num::traits::Float;
+use num_traits::Float;
 
 /// Helper function: sinc(x) = sin(pi*x)/(pi*x)
 pub fn sinc<T: Float>(value: T) -> T {

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -1,8 +1,8 @@
 use crate::sinc::make_sincs;
 use crate::windows::WindowFunction;
-use num::integer;
-use num::traits::Zero;
-use num::Complex;
+use num_complex::Complex;
+use num_integer as integer;
+use num_traits::Zero;
 use std::error;
 
 type Res<T> = Result<T, Box<dyn error::Error>>;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,4 @@
-use num::traits::Float;
+use num_traits::Float;
 
 /// Different window functions that can be used to window the sinc function.
 #[derive(Debug)]


### PR DESCRIPTION
This reduces the number of dependencies as many num-* crates
that the num crate depends on by default aren't needed.