### PR TITLE
Add support for storing output in a pre-allocated buffer

### DIFF
--- a/src/asynchro.rs
+++ b/src/asynchro.rs
@@ -328,8 +328,8 @@ macro_rules! resampler_sincfixedin {
                     for (idx, sample) in wave_in[*chan].iter().enumerate() {
                         self.buffer[*chan][idx + 2 * sinc_len] = *sample;
                     }
-                    let new_size = (self.chunk_size as f64 * self.resample_ratio + 10.0) as usize;
-                    wave_out[*chan].resize(new_size, 0.0);
+                    let new_len = (self.chunk_size as f64 * self.resample_ratio + 10.0) as usize;
+                    wave_out[*chan].resize(new_len, 0.0);
                 }
 
                 let mut idx = self.last_index;

--- a/src/asynchro.rs
+++ b/src/asynchro.rs
@@ -291,7 +291,7 @@ macro_rules! resampler_sincfixedin {
             ///
             /// The function returns an error if the length of the input data is not equal
             /// to the number of channels and chunk size defined when creating the instance.
-            fn process_in_place(
+            fn process_into_buffer(
                 &mut self,
                 wave_in: &[Vec<$t>],
                 wave_out: &mut Vec<Vec<$t>>,
@@ -561,7 +561,7 @@ macro_rules! resampler_sincfixedout {
             /// The function returns an error if the length of the input data is not
             /// equal to the number of channels defined when creating the instance,
             /// and the number of audio frames given by "nbr_frames_needed".
-            fn process_in_place(&mut self, wave_in: &[Vec<$t>], wave_out: &mut Vec<Vec<$t>>) -> Res<()> {
+            fn process_into_buffer(&mut self, wave_in: &[Vec<$t>], wave_out: &mut Vec<Vec<$t>>) -> Res<()> {
                 //update buffer with new data
                 if wave_in.len() != self.nbr_channels {
                     return Err(Box::new(ResamplerError::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,17 +186,17 @@ pub trait Resampler<T> {
     /// where each element contains a vector with all samples for a single channel.
     fn process(&mut self, wave_in: &[Vec<T>]) -> Res<Vec<Vec<T>>> {
         let mut wave_out = Vec::new();
-        self.process_in_place(wave_in, &mut wave_out)?;
+        self.process_into_buffer(wave_in, &mut wave_out)?;
         Ok(wave_out)
     }
 
     /// Resample a chunk of audio. Input and output data is stored in a vector,
     /// where each element contains a vector with all samples for a single channel.
     ///
-    /// This is the same as [process] except that it can re-use an in-place
-    /// buffer for the output waveforms. The buffer doesn't have to be zeroed
-    /// between intermediate calls.
-    fn process_in_place(&mut self, wave_in: &[Vec<T>], wave_out: &mut Vec<Vec<T>>) -> Res<()>;
+    /// This is the same as [process] except that it can re-use the `wave_out`
+    /// buffers for the output waveforms. The `wave_out` buffer doesn't have to
+    /// be zeroed between intermediate calls.
+    fn process_into_buffer(&mut self, wave_in: &[Vec<T>], wave_out: &mut Vec<Vec<T>>) -> Res<()>;
 
     /// Update the resample ratio.
     fn set_resample_ratio(&mut self, new_ratio: f64) -> Res<()>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,19 @@ pub enum InterpolationType {
 pub trait Resampler<T> {
     /// Resample a chunk of audio. Input and output data is stored in a vector,
     /// where each element contains a vector with all samples for a single channel.
-    fn process(&mut self, wave_in: &[Vec<T>]) -> Res<Vec<Vec<T>>>;
+    fn process(&mut self, wave_in: &[Vec<T>]) -> Res<Vec<Vec<T>>> {
+        let mut wave_out = Vec::new();
+        self.process_in_place(wave_in, &mut wave_out)?;
+        Ok(wave_out)
+    }
+
+    /// Resample a chunk of audio. Input and output data is stored in a vector,
+    /// where each element contains a vector with all samples for a single channel.
+    ///
+    /// This is the same as [process] except that it can re-use an in-place
+    /// buffer for the output waveforms. The buffer doesn't have to be zeroed
+    /// between intermediate calls.
+    fn process_in_place(&mut self, wave_in: &[Vec<T>], wave_out: &mut Vec<Vec<T>>) -> Res<()>;
 
     /// Update the resample ratio.
     fn set_resample_ratio(&mut self, new_ratio: f64) -> Res<()>;

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -434,8 +434,8 @@ macro_rules! resampler_FftFixedout {
 
                 wave_out.resize(self.nbr_channels, Vec::new());
                 for chan in used_channels.iter() {
-                    let output_buffer = self.output_buffers[*chan].len();
-                    wave_out[*chan].resize(output_buffer, 0.0);
+                    let new_len = self.output_buffers[*chan].len();
+                    wave_out[*chan].resize(new_len, 0.0);
                     wave_out[*chan].copy_from_slice(&self.output_buffers[*chan]);
                 }
 

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -268,7 +268,7 @@ macro_rules! resampler_FftFixedinout {
             ///
             /// The function returns an error if the size of the input data is not equal
             /// to the number of channels and input size defined when creating the instance.
-            fn process_in_place(
+            fn process_into_buffer(
                 &mut self,
                 wave_in: &[Vec<$t>],
                 wave_out: &mut Vec<Vec<$t>>,
@@ -405,7 +405,7 @@ macro_rules! resampler_FftFixedout {
             /// The function returns an error if the length of the input data is not
             /// equal to the number of channels defined when creating the instance,
             /// and the number of audio frames given by "nbr_frames_needed".
-            fn process_in_place(
+            fn process_into_buffer(
                 &mut self,
                 wave_in: &[Vec<$t>],
                 wave_out: &mut Vec<Vec<$t>>,
@@ -568,7 +568,7 @@ macro_rules! resampler_FftFixedin {
             /// The function returns an error if the length of the input data is not
             /// equal to the number of channels defined when creating the instance,
             /// and the number of audio frames given by "nbr_frames_needed".
-            fn process_in_place(
+            fn process_into_buffer(
                 &mut self,
                 wave_in: &[Vec<$t>],
                 wave_out: &mut Vec<Vec<$t>>,


### PR DESCRIPTION
Adds `process_in_place` which allows processing to happen over a potentially pre-allocated buffer. The processor will simply leave the buffer unmodified (up to the caller to decide how it's filled/cleared or what not) and make sure it's correctly sized before proceeding.

Adds a default impl for `process` which provides the same API as before.

Benchmarks don't show any regression. I did a quick run while using `process_in_place`, but it seems like it's very similar to allocating - but I expect this would depend on how large the work buffer is.