### PR TITLE
Normalize and clean up error handling a bit

### DIFF
--- a/src/asynchro.rs
+++ b/src/asynchro.rs
@@ -12,7 +12,7 @@ use crate::{InterpolationParameters, InterpolationType};
 
 use num_traits::Float;
 
-use crate::error::{Error, Result};
+use crate::error::{ResampleError, ResampleResult};
 use crate::Resampler;
 
 /// Functions for making the scalar product with a sinc
@@ -288,9 +288,9 @@ macro_rules! resampler_sincfixedin {
             ///
             /// The function returns an error if the length of the input data is not equal
             /// to the number of channels and chunk size defined when creating the instance.
-            fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
+            fn process(&mut self, wave_in: &[Vec<$t>]) -> ResampleResult<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
-                    return Err(Error::WrongNumberOfChannels {
+                    return Err(ResampleError::WrongNumberOfChannels {
                         expected: self.nbr_channels,
                         actual: wave_in.len(),
                     });
@@ -300,7 +300,7 @@ macro_rules! resampler_sincfixedin {
                     if !wave.is_empty() {
                         used_channels.push(chan);
                         if wave.len() != self.chunk_size {
-                            return Err(Error::WrongNumberOfFrames {
+                            return Err(ResampleError::WrongNumberOfFrames {
                                 channel: chan,
                                 expected: self.chunk_size,
                                 actual: wave.len(),
@@ -419,7 +419,7 @@ macro_rules! resampler_sincfixedin {
             }
 
             /// Update the resample ratio. New value must be within +-10% of the original one
-            fn set_resample_ratio(&mut self, new_ratio: f64) -> Result<()> {
+            fn set_resample_ratio(&mut self, new_ratio: f64) -> ResampleResult<()> {
                 trace!("Change resample ratio to {}", new_ratio);
                 if (new_ratio / self.resample_ratio_original > 0.9)
                     && (new_ratio / self.resample_ratio_original < 1.1)
@@ -427,11 +427,11 @@ macro_rules! resampler_sincfixedin {
                     self.resample_ratio = new_ratio;
                     Ok(())
                 } else {
-                    Err(Error::BadResampleRatioUpdate)
+                    Err(ResampleError::BadRatioUpdate)
                 }
             }
             /// Update the resample ratio relative to the original one
-            fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> Result<()> {
+            fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> ResampleResult<()> {
                 let new_ratio = self.resample_ratio_original * rel_ratio;
                 self.set_resample_ratio(new_ratio)
             }
@@ -524,7 +524,7 @@ macro_rules! resampler_sincfixedout {
             }
 
             /// Update the resample ratio. New value must be within +-10% of the original one
-            fn set_resample_ratio(&mut self, new_ratio: f64) -> Result<()> {
+            fn set_resample_ratio(&mut self, new_ratio: f64) -> ResampleResult<()> {
                 trace!("Change resample ratio to {}", new_ratio);
                 if (new_ratio / self.resample_ratio_original > 0.9)
                     && (new_ratio / self.resample_ratio_original < 1.1)
@@ -537,12 +537,12 @@ macro_rules! resampler_sincfixedout {
                         + 2;
                     Ok(())
                 } else {
-                    Err(Error::BadResampleRatioUpdate)
+                    Err(ResampleError::BadRatioUpdate)
                 }
             }
 
             /// Update the resample ratio relative to the original one
-            fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> Result<()> {
+            fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> ResampleResult<()> {
                 let new_ratio = self.resample_ratio_original * rel_ratio;
                 self.set_resample_ratio(new_ratio)
             }
@@ -556,10 +556,10 @@ macro_rules! resampler_sincfixedout {
             /// The function returns an error if the length of the input data is not
             /// equal to the number of channels defined when creating the instance,
             /// and the number of audio frames given by "nbr_frames_needed".
-            fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
+            fn process(&mut self, wave_in: &[Vec<$t>]) -> ResampleResult<Vec<Vec<$t>>> {
                 //update buffer with new data
                 if wave_in.len() != self.nbr_channels {
-                    return Err(Error::WrongNumberOfChannels {
+                    return Err(ResampleError::WrongNumberOfChannels {
                         expected: self.nbr_channels,
                         actual: wave_in.len(),
                     });
@@ -571,7 +571,7 @@ macro_rules! resampler_sincfixedout {
                     if !wave.is_empty() {
                         used_channels.push(chan);
                         if wave.len() != self.needed_input_size {
-                            return Err(Error::WrongNumberOfFrames {
+                            return Err(ResampleError::WrongNumberOfFrames {
                                 channel: chan,
                                 expected: self.needed_input_size,
                                 actual: wave.len(),

--- a/src/asynchro.rs
+++ b/src/asynchro.rs
@@ -11,12 +11,9 @@ use crate::sinc::make_sincs;
 use crate::{InterpolationParameters, InterpolationType};
 
 use num_traits::Float;
-use std::error;
 
-type Res<T> = Result<T, Box<dyn error::Error>>;
-
+use crate::error::{ResamplerError, Result};
 use crate::Resampler;
-use crate::ResamplerError;
 
 /// Functions for making the scalar product with a sinc
 pub trait SincInterpolator<T> {
@@ -291,7 +288,7 @@ macro_rules! resampler_sincfixedin {
             ///
             /// The function returns an error if the length of the input data is not equal
             /// to the number of channels and chunk size defined when creating the instance.
-            fn process(&mut self, wave_in: &[Vec<$t>]) -> Res<Vec<Vec<$t>>> {
+            fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
                     return Err(Box::new(ResamplerError::new(
                         "Wrong number of channels in input",
@@ -419,7 +416,7 @@ macro_rules! resampler_sincfixedin {
             }
 
             /// Update the resample ratio. New value must be within +-10% of the original one
-            fn set_resample_ratio(&mut self, new_ratio: f64) -> Res<()> {
+            fn set_resample_ratio(&mut self, new_ratio: f64) -> Result<()> {
                 trace!("Change resample ratio to {}", new_ratio);
                 if (new_ratio / self.resample_ratio_original > 0.9)
                     && (new_ratio / self.resample_ratio_original < 1.1)
@@ -433,7 +430,7 @@ macro_rules! resampler_sincfixedin {
                 }
             }
             /// Update the resample ratio relative to the original one
-            fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> Res<()> {
+            fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> Result<()> {
                 let new_ratio = self.resample_ratio_original * rel_ratio;
                 self.set_resample_ratio(new_ratio)
             }
@@ -526,7 +523,7 @@ macro_rules! resampler_sincfixedout {
             }
 
             /// Update the resample ratio. New value must be within +-10% of the original one
-            fn set_resample_ratio(&mut self, new_ratio: f64) -> Res<()> {
+            fn set_resample_ratio(&mut self, new_ratio: f64) -> Result<()> {
                 trace!("Change resample ratio to {}", new_ratio);
                 if (new_ratio / self.resample_ratio_original > 0.9)
                     && (new_ratio / self.resample_ratio_original < 1.1)
@@ -546,7 +543,7 @@ macro_rules! resampler_sincfixedout {
             }
 
             /// Update the resample ratio relative to the original one
-            fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> Res<()> {
+            fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> Result<()> {
                 let new_ratio = self.resample_ratio_original * rel_ratio;
                 self.set_resample_ratio(new_ratio)
             }
@@ -560,7 +557,7 @@ macro_rules! resampler_sincfixedout {
             /// The function returns an error if the length of the input data is not
             /// equal to the number of channels defined when creating the instance,
             /// and the number of audio frames given by "nbr_frames_needed".
-            fn process(&mut self, wave_in: &[Vec<$t>]) -> Res<Vec<Vec<$t>>> {
+            fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
                 //update buffer with new data
                 if wave_in.len() != self.nbr_channels {
                     return Err(Box::new(ResamplerError::new(

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,10 +3,10 @@ use std::fmt;
 
 /// The error type used by `rubato`.
 #[derive(Debug)]
-pub enum Error {
+pub enum ResampleError {
     /// Error raised when Resample::set_resample_ratio is called with a ratio
     /// that deviates for more than 10% of the original.
-    BadResampleRatioUpdate,
+    BadRatioUpdate,
     /// Error raised when trying to adjust a synchronous resampler.
     SyncNotAdjustable,
     /// Error raised when the number of channels doesn't match expected.
@@ -20,10 +20,10 @@ pub enum Error {
     },
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for ResampleError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::BadResampleRatioUpdate => {
+            Self::BadRatioUpdate => {
                 write!(f, "New resample ratio is too far off from original")
             }
             Self::SyncNotAdjustable { .. } => {
@@ -51,7 +51,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {}
+impl error::Error for ResampleError {}
 
 /// A result alias for the error type used by `rubato`.
-pub type Result<T, E = Error> = ::std::result::Result<T, E>;
+pub type ResampleResult<T> = ::std::result::Result<T, ResampleError>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,32 @@
+use std::error;
+use std::fmt;
+
+/// The error type used by `rubato`.
+pub type Error = Box<dyn error::Error + Send + Sync + 'static>;
+
+/// A result alias for the error type used by `rubato`.
+pub type Result<T, E = Error> = ::std::result::Result<T, E>;
+
+/// Custom error returned by resamplers.
+#[derive(Debug)]
+pub struct ResamplerError {
+    desc: Box<str>,
+}
+
+impl fmt::Display for ResamplerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.desc)
+    }
+}
+
+impl error::Error for ResamplerError {
+    fn description(&self) -> &str {
+        &self.desc
+    }
+}
+
+impl ResamplerError {
+    pub fn new(desc: &str) -> Self {
+        ResamplerError { desc: desc.into() }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,31 +2,56 @@ use std::error;
 use std::fmt;
 
 /// The error type used by `rubato`.
-pub type Error = Box<dyn error::Error + Send + Sync + 'static>;
+#[derive(Debug)]
+pub enum Error {
+    /// Error raised when Resample::set_resample_ratio is called with a ratio
+    /// that deviates for more than 10% of the original.
+    BadResampleRatioUpdate,
+    /// Error raised when trying to adjust a synchronous resampler.
+    SyncNotAdjustable,
+    /// Error raised when the number of channels doesn't match expected.
+    WrongNumberOfChannels { expected: usize, actual: usize },
+    /// Error raised when the number of frames in a single channel doesn't match
+    /// the expected.
+    WrongNumberOfFrames {
+        channel: usize,
+        expected: usize,
+        actual: usize,
+    },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadResampleRatioUpdate => {
+                write!(f, "New resample ratio is too far off from original")
+            }
+            Self::SyncNotAdjustable { .. } => {
+                write!(f, "Not possible to adjust a synchronous resampler")
+            }
+            Self::WrongNumberOfChannels { expected, actual } => {
+                write!(
+                    f,
+                    "Wrong number of channels {} in input, expected {}",
+                    actual, expected
+                )
+            }
+            Self::WrongNumberOfFrames {
+                channel,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "Wrong number of frames {} in input channel {}, expected {}",
+                    actual, channel, expected
+                )
+            }
+        }
+    }
+}
+
+impl error::Error for Error {}
 
 /// A result alias for the error type used by `rubato`.
 pub type Result<T, E = Error> = ::std::result::Result<T, E>;
-
-/// Custom error returned by resamplers.
-#[derive(Debug)]
-pub struct ResamplerError {
-    desc: Box<str>,
-}
-
-impl fmt::Display for ResamplerError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.desc)
-    }
-}
-
-impl error::Error for ResamplerError {
-    fn description(&self) -> &str {
-        &self.desc
-    }
-}
-
-impl ResamplerError {
-    pub fn new(desc: &str) -> Self {
-        ResamplerError { desc: desc.into() }
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@
 #![cfg_attr(feature = "neon", feature(stdsimd))]
 
 mod asynchro;
+mod error;
 mod interpolation;
 #[cfg(all(target_arch = "x86_64", feature = "avx"))]
 pub mod interpolator_avx;
@@ -89,39 +90,10 @@ pub use crate::asynchro::{ScalarInterpolator, SincFixedIn, SincFixedOut};
 pub use crate::synchro::{FftFixedIn, FftFixedInOut, FftFixedOut};
 pub use crate::windows::WindowFunction;
 
-use std::error;
-use std::fmt;
+pub use crate::error::{Error, Result};
 
 #[macro_use]
 extern crate log;
-
-type Res<T> = Result<T, Box<dyn error::Error>>;
-
-/// Custom error returned by resamplers
-#[derive(Debug)]
-pub struct ResamplerError {
-    desc: String,
-}
-
-impl fmt::Display for ResamplerError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.desc)
-    }
-}
-
-impl error::Error for ResamplerError {
-    fn description(&self) -> &str {
-        &self.desc
-    }
-}
-
-impl ResamplerError {
-    pub fn new(desc: &str) -> Self {
-        ResamplerError {
-            desc: desc.to_owned(),
-        }
-    }
-}
 
 /// A struct holding the parameters for interpolation.
 #[derive(Debug)]
@@ -184,13 +156,13 @@ pub enum InterpolationType {
 pub trait Resampler<T> {
     /// Resample a chunk of audio. Input and output data is stored in a vector,
     /// where each element contains a vector with all samples for a single channel.
-    fn process(&mut self, wave_in: &[Vec<T>]) -> Res<Vec<Vec<T>>>;
+    fn process(&mut self, wave_in: &[Vec<T>]) -> Result<Vec<Vec<T>>>;
 
     /// Update the resample ratio.
-    fn set_resample_ratio(&mut self, new_ratio: f64) -> Res<()>;
+    fn set_resample_ratio(&mut self, new_ratio: f64) -> Result<()>;
 
     /// Update the resample ratio relative to the original one.
-    fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> Res<()>;
+    fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> Result<()>;
 
     /// Query for the number of frames needed for the next call to "process".
     fn nbr_frames_needed(&self) -> usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub use crate::asynchro::{ScalarInterpolator, SincFixedIn, SincFixedOut};
 pub use crate::synchro::{FftFixedIn, FftFixedInOut, FftFixedOut};
 pub use crate::windows::WindowFunction;
 
-pub use crate::error::{Error, Result};
+pub use crate::error::{ResampleError, ResampleResult};
 
 #[macro_use]
 extern crate log;
@@ -156,13 +156,13 @@ pub enum InterpolationType {
 pub trait Resampler<T> {
     /// Resample a chunk of audio. Input and output data is stored in a vector,
     /// where each element contains a vector with all samples for a single channel.
-    fn process(&mut self, wave_in: &[Vec<T>]) -> Result<Vec<Vec<T>>>;
+    fn process(&mut self, wave_in: &[Vec<T>]) -> ResampleResult<Vec<Vec<T>>>;
 
     /// Update the resample ratio.
-    fn set_resample_ratio(&mut self, new_ratio: f64) -> Result<()>;
+    fn set_resample_ratio(&mut self, new_ratio: f64) -> ResampleResult<()>;
 
     /// Update the resample ratio relative to the original one.
-    fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> Result<()>;
+    fn set_resample_ratio_relative(&mut self, rel_ratio: f64) -> ResampleResult<()>;
 
     /// Query for the number of frames needed for the next call to "process".
     fn nbr_frames_needed(&self) -> usize;

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -1,15 +1,13 @@
+use crate::error::Result;
 use crate::sinc::make_sincs;
 use crate::windows::WindowFunction;
 use num_complex::Complex;
 use num_integer as integer;
 use num_traits::Zero;
-use std::error;
 use std::sync::Arc;
 
-type Res<T> = Result<T, Box<dyn error::Error>>;
-
+use crate::error::ResamplerError;
 use crate::Resampler;
-use crate::ResamplerError;
 use realfft::{ComplexToReal, RealFftPlanner, RealToComplex};
 
 /// A helper for resampling a single chunk of data.
@@ -247,7 +245,7 @@ macro_rules! resampler_FftFixedinout {
             }
 
             /// Update the resample ratio. This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio(&mut self, _new_ratio: f64) -> Res<()> {
+            fn set_resample_ratio(&mut self, _new_ratio: f64) -> Result<()> {
                 Err(Box::new(ResamplerError::new(
                     "Not possible to adjust a synchronous resampler)",
                 )))
@@ -255,7 +253,7 @@ macro_rules! resampler_FftFixedinout {
 
             /// Update the resample ratio relative to the original one.
             /// This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Res<()> {
+            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Result<()> {
                 Err(Box::new(ResamplerError::new(
                     "Not possible to adjust a synchronous resampler)",
                 )))
@@ -268,7 +266,7 @@ macro_rules! resampler_FftFixedinout {
             ///
             /// The function returns an error if the size of the input data is not equal
             /// to the number of channels and input size defined when creating the instance.
-            fn process(&mut self, wave_in: &[Vec<$t>]) -> Res<Vec<Vec<$t>>> {
+            fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
                     return Err(Box::new(ResamplerError::new(
                         "Wrong number of channels in input",
@@ -378,7 +376,7 @@ macro_rules! resampler_FftFixedout {
             }
 
             /// Update the resample ratio. This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio(&mut self, _new_ratio: f64) -> Res<()> {
+            fn set_resample_ratio(&mut self, _new_ratio: f64) -> Result<()> {
                 Err(Box::new(ResamplerError::new(
                     "Not possible to adjust a synchronous resampler)",
                 )))
@@ -386,7 +384,7 @@ macro_rules! resampler_FftFixedout {
 
             /// Update the resample ratio relative to the original one.
             /// This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Res<()> {
+            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Result<()> {
                 Err(Box::new(ResamplerError::new(
                     "Not possible to adjust a synchronous resampler)",
                 )))
@@ -401,7 +399,7 @@ macro_rules! resampler_FftFixedout {
             /// The function returns an error if the length of the input data is not
             /// equal to the number of channels defined when creating the instance,
             /// and the number of audio frames given by "nbr_frames_needed".
-            fn process(&mut self, wave_in: &[Vec<$t>]) -> Res<Vec<Vec<$t>>> {
+            fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
                     return Err(Box::new(ResamplerError::new(
                         "Wrong number of channels in input",
@@ -535,7 +533,7 @@ macro_rules! resampler_FftFixedin {
             }
 
             /// Update the resample ratio. This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio(&mut self, _new_ratio: f64) -> Res<()> {
+            fn set_resample_ratio(&mut self, _new_ratio: f64) -> Result<()> {
                 Err(Box::new(ResamplerError::new(
                     "Not possible to adjust a synchronous resampler)",
                 )))
@@ -543,7 +541,7 @@ macro_rules! resampler_FftFixedin {
 
             /// Update the resample ratio relative to the original one.
             /// This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Res<()> {
+            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Result<()> {
                 Err(Box::new(ResamplerError::new(
                     "Not possible to adjust a synchronous resampler)",
                 )))
@@ -558,7 +556,7 @@ macro_rules! resampler_FftFixedin {
             /// The function returns an error if the length of the input data is not
             /// equal to the number of channels defined when creating the instance,
             /// and the number of audio frames given by "nbr_frames_needed".
-            fn process(&mut self, wave_in: &[Vec<$t>]) -> Res<Vec<Vec<$t>>> {
+            fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
                     return Err(Box::new(ResamplerError::new(
                         "Wrong number of channels in input",

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -1,4 +1,3 @@
-use crate::error::Result;
 use crate::sinc::make_sincs;
 use crate::windows::WindowFunction;
 use num_complex::Complex;
@@ -6,7 +5,7 @@ use num_integer as integer;
 use num_traits::Zero;
 use std::sync::Arc;
 
-use crate::error::Error;
+use crate::error::{ResampleError, ResampleResult};
 use crate::Resampler;
 use realfft::{ComplexToReal, RealFftPlanner, RealToComplex};
 
@@ -245,14 +244,14 @@ macro_rules! resampler_FftFixedinout {
             }
 
             /// Update the resample ratio. This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio(&mut self, _new_ratio: f64) -> Result<()> {
-                Err(Error::SyncNotAdjustable)
+            fn set_resample_ratio(&mut self, _new_ratio: f64) -> ResampleResult<()> {
+                Err(ResampleError::SyncNotAdjustable)
             }
 
             /// Update the resample ratio relative to the original one.
             /// This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Result<()> {
-                Err(Error::SyncNotAdjustable)
+            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> ResampleResult<()> {
+                Err(ResampleError::SyncNotAdjustable)
             }
 
             /// Resample a chunk of audio. The input and output lengths are fixed.
@@ -262,9 +261,9 @@ macro_rules! resampler_FftFixedinout {
             ///
             /// The function returns an error if the size of the input data is not equal
             /// to the number of channels and input size defined when creating the instance.
-            fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
+            fn process(&mut self, wave_in: &[Vec<$t>]) -> ResampleResult<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
-                    return Err(Error::WrongNumberOfChannels {
+                    return Err(ResampleError::WrongNumberOfChannels {
                         expected: self.nbr_channels,
                         actual: wave_in.len(),
                     });
@@ -274,7 +273,7 @@ macro_rules! resampler_FftFixedinout {
                     if !wave.is_empty() {
                         used_channels.push(chan);
                         if wave.len() != self.chunk_size_in {
-                            return Err(Error::WrongNumberOfFrames {
+                            return Err(ResampleError::WrongNumberOfFrames {
                                 channel: chan,
                                 expected: self.chunk_size_in,
                                 actual: wave.len(),
@@ -370,14 +369,14 @@ macro_rules! resampler_FftFixedout {
             }
 
             /// Update the resample ratio. This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio(&mut self, _new_ratio: f64) -> Result<()> {
-                Err(Error::SyncNotAdjustable)
+            fn set_resample_ratio(&mut self, _new_ratio: f64) -> ResampleResult<()> {
+                Err(ResampleError::SyncNotAdjustable)
             }
 
             /// Update the resample ratio relative to the original one.
             /// This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Result<()> {
-                Err(Error::SyncNotAdjustable)
+            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> ResampleResult<()> {
+                Err(ResampleError::SyncNotAdjustable)
             }
 
             /// Resample a chunk of audio. The required input length is provided by
@@ -389,9 +388,9 @@ macro_rules! resampler_FftFixedout {
             /// The function returns an error if the length of the input data is not
             /// equal to the number of channels defined when creating the instance,
             /// and the number of audio frames given by "nbr_frames_needed".
-            fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
+            fn process(&mut self, wave_in: &[Vec<$t>]) -> ResampleResult<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
-                    return Err(Error::WrongNumberOfChannels {
+                    return Err(ResampleError::WrongNumberOfChannels {
                         expected: self.nbr_channels,
                         actual: wave_in.len(),
                     });
@@ -401,7 +400,7 @@ macro_rules! resampler_FftFixedout {
                     if !wave.is_empty() {
                         used_channels.push(chan);
                         if wave.len() != self.frames_needed {
-                            return Err(Error::WrongNumberOfFrames {
+                            return Err(ResampleError::WrongNumberOfFrames {
                                 channel: chan,
                                 expected: self.frames_needed,
                                 actual: wave.len(),
@@ -521,14 +520,14 @@ macro_rules! resampler_FftFixedin {
             }
 
             /// Update the resample ratio. This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio(&mut self, _new_ratio: f64) -> Result<()> {
-                Err(Error::SyncNotAdjustable)
+            fn set_resample_ratio(&mut self, _new_ratio: f64) -> ResampleResult<()> {
+                Err(ResampleError::SyncNotAdjustable)
             }
 
             /// Update the resample ratio relative to the original one.
             /// This is not supported by this resampler and always returns an error.
-            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Result<()> {
-                Err(Error::SyncNotAdjustable)
+            fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> ResampleResult<()> {
+                Err(ResampleError::SyncNotAdjustable)
             }
 
             /// Resample a chunk of audio. The required input length is provided by
@@ -540,9 +539,9 @@ macro_rules! resampler_FftFixedin {
             /// The function returns an error if the length of the input data is not
             /// equal to the number of channels defined when creating the instance,
             /// and the number of audio frames given by "nbr_frames_needed".
-            fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
+            fn process(&mut self, wave_in: &[Vec<$t>]) -> ResampleResult<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
-                    return Err(Error::WrongNumberOfChannels {
+                    return Err(ResampleError::WrongNumberOfChannels {
                         expected: self.nbr_channels,
                         actual: wave_in.len(),
                     });
@@ -552,7 +551,7 @@ macro_rules! resampler_FftFixedin {
                     if !wave.is_empty() {
                         used_channels.push(chan);
                         if wave.len() != self.chunk_size_in {
-                            return Err(Error::WrongNumberOfFrames {
+                            return Err(ResampleError::WrongNumberOfFrames {
                                 channel: chan,
                                 expected: self.chunk_size_in,
                                 actual: wave.len(),

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -6,7 +6,7 @@ use num_integer as integer;
 use num_traits::Zero;
 use std::sync::Arc;
 
-use crate::error::ResamplerError;
+use crate::error::Error;
 use crate::Resampler;
 use realfft::{ComplexToReal, RealFftPlanner, RealToComplex};
 
@@ -246,17 +246,13 @@ macro_rules! resampler_FftFixedinout {
 
             /// Update the resample ratio. This is not supported by this resampler and always returns an error.
             fn set_resample_ratio(&mut self, _new_ratio: f64) -> Result<()> {
-                Err(Box::new(ResamplerError::new(
-                    "Not possible to adjust a synchronous resampler)",
-                )))
+                Err(Error::SyncNotAdjustable)
             }
 
             /// Update the resample ratio relative to the original one.
             /// This is not supported by this resampler and always returns an error.
             fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Result<()> {
-                Err(Box::new(ResamplerError::new(
-                    "Not possible to adjust a synchronous resampler)",
-                )))
+                Err(Error::SyncNotAdjustable)
             }
 
             /// Resample a chunk of audio. The input and output lengths are fixed.
@@ -268,23 +264,21 @@ macro_rules! resampler_FftFixedinout {
             /// to the number of channels and input size defined when creating the instance.
             fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
-                    return Err(Box::new(ResamplerError::new(
-                        "Wrong number of channels in input",
-                    )));
+                    return Err(Error::WrongNumberOfChannels {
+                        expected: self.nbr_channels,
+                        actual: wave_in.len(),
+                    });
                 }
                 let mut used_channels = Vec::new();
                 for (chan, wave) in wave_in.iter().enumerate() {
                     if !wave.is_empty() {
                         used_channels.push(chan);
                         if wave.len() != self.chunk_size_in {
-                            return Err(Box::new(ResamplerError::new(
-                                format!(
-                                    "Wrong number of frames in input, expected {}, got {}",
-                                    self.chunk_size_in,
-                                    wave_in[0].len()
-                                )
-                                .as_str(),
-                            )));
+                            return Err(Error::WrongNumberOfFrames {
+                                channel: chan,
+                                expected: self.chunk_size_in,
+                                actual: wave.len(),
+                            });
                         }
                     }
                 }
@@ -377,17 +371,13 @@ macro_rules! resampler_FftFixedout {
 
             /// Update the resample ratio. This is not supported by this resampler and always returns an error.
             fn set_resample_ratio(&mut self, _new_ratio: f64) -> Result<()> {
-                Err(Box::new(ResamplerError::new(
-                    "Not possible to adjust a synchronous resampler)",
-                )))
+                Err(Error::SyncNotAdjustable)
             }
 
             /// Update the resample ratio relative to the original one.
             /// This is not supported by this resampler and always returns an error.
             fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Result<()> {
-                Err(Box::new(ResamplerError::new(
-                    "Not possible to adjust a synchronous resampler)",
-                )))
+                Err(Error::SyncNotAdjustable)
             }
 
             /// Resample a chunk of audio. The required input length is provided by
@@ -401,23 +391,21 @@ macro_rules! resampler_FftFixedout {
             /// and the number of audio frames given by "nbr_frames_needed".
             fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
-                    return Err(Box::new(ResamplerError::new(
-                        "Wrong number of channels in input",
-                    )));
+                    return Err(Error::WrongNumberOfChannels {
+                        expected: self.nbr_channels,
+                        actual: wave_in.len(),
+                    });
                 }
                 let mut used_channels = Vec::new();
                 for (chan, wave) in wave_in.iter().enumerate() {
                     if !wave.is_empty() {
                         used_channels.push(chan);
                         if wave.len() != self.frames_needed {
-                            return Err(Box::new(ResamplerError::new(
-                                format!(
-                                    "Wrong number of frames in input, expected {}, got {}",
-                                    self.frames_needed,
-                                    wave.len()
-                                )
-                                .as_str(),
-                            )));
+                            return Err(Error::WrongNumberOfFrames {
+                                channel: chan,
+                                expected: self.frames_needed,
+                                actual: wave.len(),
+                            });
                         }
                     }
                 }
@@ -534,17 +522,13 @@ macro_rules! resampler_FftFixedin {
 
             /// Update the resample ratio. This is not supported by this resampler and always returns an error.
             fn set_resample_ratio(&mut self, _new_ratio: f64) -> Result<()> {
-                Err(Box::new(ResamplerError::new(
-                    "Not possible to adjust a synchronous resampler)",
-                )))
+                Err(Error::SyncNotAdjustable)
             }
 
             /// Update the resample ratio relative to the original one.
             /// This is not supported by this resampler and always returns an error.
             fn set_resample_ratio_relative(&mut self, _rel_ratio: f64) -> Result<()> {
-                Err(Box::new(ResamplerError::new(
-                    "Not possible to adjust a synchronous resampler)",
-                )))
+                Err(Error::SyncNotAdjustable)
             }
 
             /// Resample a chunk of audio. The required input length is provided by
@@ -558,23 +542,21 @@ macro_rules! resampler_FftFixedin {
             /// and the number of audio frames given by "nbr_frames_needed".
             fn process(&mut self, wave_in: &[Vec<$t>]) -> Result<Vec<Vec<$t>>> {
                 if wave_in.len() != self.nbr_channels {
-                    return Err(Box::new(ResamplerError::new(
-                        "Wrong number of channels in input",
-                    )));
+                    return Err(Error::WrongNumberOfChannels {
+                        expected: self.nbr_channels,
+                        actual: wave_in.len(),
+                    });
                 }
                 let mut used_channels = Vec::new();
                 for (chan, wave) in wave_in.iter().enumerate() {
                     if !wave.is_empty() {
                         used_channels.push(chan);
                         if wave.len() != self.chunk_size_in {
-                            return Err(Box::new(ResamplerError::new(
-                                format!(
-                                    "Wrong number of frames in input, expected {}, got {}",
-                                    self.chunk_size_in,
-                                    wave.len()
-                                )
-                                .as_str(),
-                            )));
+                            return Err(Error::WrongNumberOfFrames {
+                                channel: chan,
+                                expected: self.chunk_size_in,
+                                actual: wave.len(),
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
So the goal of this PR is twofold:
* An effort to make the library's naming convention a bit more idiomatic.
* Move all the error stuff into its own internal module instead of repeating it.
* Make the error type `Send + Sync + 'static` so it works with [`anyhow`](https://docs.rs/anyhow).

We define the following items in a single place `mod error` and export them publicly:
* `Result` (renamed from `Res`) which is an `Error` defaulting alias to `std::result::Result`, so it can be used like `rubato::Result<()>` or similarly.
* `Error` which is the error type `rubato` uses and the specific `ResamplerError`.

`ResamplerError` stores a `Box<str>` instead of a `String`, making it a `usize` smaller.

This is a breaking change because the signature of the `Error` type has changed. So just be aware that any releasing following this needs to reflect that.