### PR TITLE
Accept any AsRef<[T]> as input

### DIFF
--- a/src/asynchro.rs
+++ b/src/asynchro.rs
@@ -301,7 +301,7 @@ where
     ///
     /// The function returns an error if the length of the input data is not equal
     /// to the number of channels and chunk size defined when creating the instance.
-    fn process(&mut self, wave_in: &[Vec<T>]) -> ResampleResult<Vec<Vec<T>>> {
+    fn process<V: AsRef<[T]>>(&mut self, wave_in: &[V]) -> ResampleResult<Vec<Vec<T>>> {
         if wave_in.len() != self.nbr_channels {
             return Err(ResampleError::WrongNumberOfChannels {
                 expected: self.nbr_channels,
@@ -310,6 +310,7 @@ where
         }
         let mut used_channels = Vec::new();
         for (chan, wave) in wave_in.iter().enumerate() {
+            let wave = wave.as_ref();
             if !wave.is_empty() {
                 used_channels.push(chan);
                 if wave.len() != self.chunk_size {
@@ -335,7 +336,7 @@ where
         let mut wave_out = vec![Vec::new(); self.nbr_channels];
 
         for chan in used_channels.iter() {
-            for (idx, sample) in wave_in[*chan].iter().enumerate() {
+            for (idx, sample) in wave_in[*chan].as_ref().iter().enumerate() {
                 self.buffer[*chan][idx + 2 * sinc_len] = *sample;
             }
             wave_out[*chan] =
@@ -544,7 +545,7 @@ where
     /// The function returns an error if the length of the input data is not
     /// equal to the number of channels defined when creating the instance,
     /// and the number of audio frames given by "nbr_frames_needed".
-    fn process(&mut self, wave_in: &[Vec<T>]) -> ResampleResult<Vec<Vec<T>>> {
+    fn process<V: AsRef<[T]>>(&mut self, wave_in: &[V]) -> ResampleResult<Vec<Vec<T>>> {
         //update buffer with new data
         if wave_in.len() != self.nbr_channels {
             return Err(ResampleError::WrongNumberOfChannels {
@@ -556,6 +557,7 @@ where
         let oversampling_factor = self.interpolator.nbr_sincs();
         let mut used_channels = Vec::new();
         for (chan, wave) in wave_in.iter().enumerate() {
+            let wave = wave.as_ref();
             if !wave.is_empty() {
                 used_channels.push(chan);
                 if wave.len() != self.needed_input_size {
@@ -577,7 +579,7 @@ where
         let mut wave_out = vec![Vec::new(); self.nbr_channels];
 
         for chan in used_channels.iter() {
-            for (idx, sample) in wave_in[*chan].iter().enumerate() {
+            for (idx, sample) in wave_in[*chan].as_ref().iter().enumerate() {
                 self.buffer[*chan][idx + 2 * sinc_len] = *sample;
             }
             wave_out[*chan] = vec![T::zero(); self.chunk_size];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,8 +194,12 @@ pub enum InterpolationType {
 /// A resampler that us used to resample a chunk of audio to a new sample rate.
 /// The rate can be adjusted as required.
 pub trait Resampler<T> {
-    /// Resample a chunk of audio. Input and output data is stored in a vector,
-    /// where each element contains a vector with all samples for a single channel.
+    /// Resample a chunk of audio.
+    ///
+    /// The input data is a slice, where each element of the slice is itself referenceable as a slice
+    /// ([`AsRef<[T]>`](AsRef)) which contains the samples for a single channel. Since [`Vec<T>`] implements
+    /// [`AsRef<[T]>`](AsRef), the input may simply be `&*Vec<Vec<T>>`. The output data is a vector, where each element
+    /// of the vector is itself a vector which contains the samples for a single channel.
     fn process<V: AsRef<[T]>>(&mut self, wave_in: &[V]) -> ResampleResult<Vec<Vec<T>>>;
 
     /// Query for the number of frames needed for the next call to "process".

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,7 @@ pub enum InterpolationType {
 pub trait Resampler<T> {
     /// Resample a chunk of audio. Input and output data is stored in a vector,
     /// where each element contains a vector with all samples for a single channel.
-    fn process(&mut self, wave_in: &[Vec<T>]) -> ResampleResult<Vec<Vec<T>>>;
+    fn process<V: AsRef<[T]>>(&mut self, wave_in: &[V]) -> ResampleResult<Vec<Vec<T>>>;
 
     /// Query for the number of frames needed for the next call to "process".
     fn nbr_frames_needed(&self) -> usize;

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -230,7 +230,7 @@ where
     ///
     /// The function returns an error if the size of the input data is not equal
     /// to the number of channels and input size defined when creating the instance.
-    fn process(&mut self, wave_in: &[Vec<T>]) -> ResampleResult<Vec<Vec<T>>> {
+    fn process<V: AsRef<[T]>>(&mut self, wave_in: &[V]) -> ResampleResult<Vec<Vec<T>>> {
         if wave_in.len() != self.nbr_channels {
             return Err(ResampleError::WrongNumberOfChannels {
                 expected: self.nbr_channels,
@@ -239,6 +239,7 @@ where
         }
         let mut used_channels = Vec::new();
         for (chan, wave) in wave_in.iter().enumerate() {
+            let wave = wave.as_ref();
             if !wave.is_empty() {
                 used_channels.push(chan);
                 if wave.len() != self.chunk_size_in {
@@ -256,8 +257,11 @@ where
         }
 
         for n in used_channels.iter() {
-            self.resampler
-                .resample_unit(&wave_in[*n], &mut wave_out[*n], &mut self.overlaps[*n])
+            self.resampler.resample_unit(
+                wave_in[*n].as_ref(),
+                &mut wave_out[*n],
+                &mut self.overlaps[*n],
+            )
         }
         Ok(wave_out)
     }
@@ -348,7 +352,7 @@ where
     /// The function returns an error if the length of the input data is not
     /// equal to the number of channels defined when creating the instance,
     /// and the number of audio frames given by "nbr_frames_needed".
-    fn process(&mut self, wave_in: &[Vec<T>]) -> ResampleResult<Vec<Vec<T>>> {
+    fn process<V: AsRef<[T]>>(&mut self, wave_in: &[V]) -> ResampleResult<Vec<Vec<T>>> {
         if wave_in.len() != self.nbr_channels {
             return Err(ResampleError::WrongNumberOfChannels {
                 expected: self.nbr_channels,
@@ -357,6 +361,7 @@ where
         }
         let mut used_channels = Vec::new();
         for (chan, wave) in wave_in.iter().enumerate() {
+            let wave = wave.as_ref();
             if !wave.is_empty() {
                 used_channels.push(chan);
                 if wave.len() != self.frames_needed {
@@ -376,6 +381,7 @@ where
 
         for n in used_channels.iter() {
             for (in_chunk, out_chunk) in wave_in[*n]
+                .as_ref()
                 .chunks(self.fft_size_in)
                 .zip(wave_out[*n][self.saved_frames..].chunks_mut(self.fft_size_out))
             {
@@ -491,7 +497,7 @@ where
     /// The function returns an error if the length of the input data is not
     /// equal to the number of channels defined when creating the instance,
     /// and the number of audio frames given by "nbr_frames_needed".
-    fn process(&mut self, wave_in: &[Vec<T>]) -> ResampleResult<Vec<Vec<T>>> {
+    fn process<V: AsRef<[T]>>(&mut self, wave_in: &[V]) -> ResampleResult<Vec<Vec<T>>> {
         if wave_in.len() != self.nbr_channels {
             return Err(ResampleError::WrongNumberOfChannels {
                 expected: self.nbr_channels,
@@ -500,6 +506,7 @@ where
         }
         let mut used_channels = Vec::new();
         for (chan, wave) in wave_in.iter().enumerate() {
+            let wave = wave.as_ref();
             if !wave.is_empty() {
                 used_channels.push(chan);
                 if wave.len() != self.chunk_size_in {
@@ -528,7 +535,7 @@ where
             }
         }
         for n in used_channels.iter() {
-            for (input, buffer) in wave_in[*n].iter().zip(
+            for (input, buffer) in wave_in[*n].as_ref().iter().zip(
                 input_temp[*n]
                     .iter_mut()
                     .skip(self.saved_frames)


### PR DESCRIPTION
Since Vec<T> implements AsRef<[T]>, this API change should be backward-compatible.

Looking at how the input is consumed in the trait implementations, I think we could easily go even farther with flexibility of the input here, accepting a slice of `impl IntoIterator<Item = T, IntoIter = impl ExactSizeIterator>`, which might be useful for e.g. inputs from `VecDeque<T>` for example, with the tradeoff of having a complex method signature.