### PR TITLE
Implement Send

### DIFF
--- a/src/asynchro.rs
+++ b/src/asynchro.rs
@@ -12,7 +12,7 @@ use crate::{InterpolationParameters, InterpolationType};
 use crate::{Resampler, Sample};
 
 /// Functions for making the scalar product with a sinc
-pub trait SincInterpolator<T> {
+pub trait SincInterpolator<T>: Send {
     /// Make the scalar product between the waveform starting at `index` and the sinc of `subindex`.
     fn get_sinc_interpolated(&self, wave: &[T], index: usize, subindex: usize) -> T;
 

--- a/src/interpolator_neon.rs
+++ b/src/interpolator_neon.rs
@@ -1,31 +1,31 @@
 use crate::asynchro::SincInterpolator;
+use crate::error::{CpuFeature, MissingCpuFeature};
 use crate::sinc::make_sincs;
 use crate::windows::WindowFunction;
-use core::arch::aarch64::{float32x4_t, float64x2_t};
-use core::arch::aarch64::{vaddq_f32, vmulq_f32, vld1q_f32, vld1q_dup_f32};
-use core::arch::aarch64::{vaddq_f64, vmulq_f64, vld1q_f64};
-use crate::error::{MissingCpuFeature, CpuFeature};
 use crate::Sample;
+use core::arch::aarch64::{float32x4_t, float64x2_t};
+use core::arch::aarch64::{vaddq_f32, vld1q_dup_f32, vld1q_f32, vmulq_f32};
+use core::arch::aarch64::{vaddq_f64, vld1q_f64, vmulq_f64};
 
 /// Collection of cpu features required for this interpolator.
 static FEATURES: &[CpuFeature] = &[CpuFeature::Neon];
 
 /// Trait governing what can be done with an NeonSample.
-pub trait NeonSample: Sized {
+pub trait NeonSample: Sized + Send {
     type Sinc;
 
     /// Pack sincs into a vector.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// This is unsafe because it uses target_enable dispatching. There are no
     /// special requirements from the caller.
     unsafe fn pack_sincs(sincs: Vec<Vec<Self>>) -> Vec<Vec<Self::Sinc>>;
 
     /// Interpolate a sinc sample.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// The caller must ensure that the various indexes are not out of bounds
     /// in the collection of sincs.
     unsafe fn get_sinc_interpolated_unsafe(
@@ -46,7 +46,7 @@ impl NeonSample for f32 {
         for sinc in sincs.iter() {
             let mut packed = Vec::new();
             for elements in sinc.chunks(4) {
-                let packed_elems = vld1q_f32(&elements[0]); 
+                let packed_elems = vld1q_f32(&elements[0]);
                 packed.push(packed_elems);
             }
             packed_sincs.push(packed);
@@ -79,7 +79,7 @@ impl NeonSample for f32 {
             s_idx += 2;
         }
         let packedsum = vaddq_f32(acc0, acc1);
-	let array = core::slice::from_raw_parts(&packedsum as *const _ as *const f32 , 4);
+        let array = core::slice::from_raw_parts(&packedsum as *const _ as *const f32, 4);
         array[0] + array[1] + array[2] + array[3]
     }
 }
@@ -119,9 +119,9 @@ impl NeonSample for f64 {
         let mut s_idx = 0;
         for _ in 0..wave_cut.len() / 8 {
             let w0 = vld1q_f64(wave_cut.get_unchecked(w_idx));
-            let w1 = vld1q_f64(wave_cut.get_unchecked(w_idx+2));
-            let w2 = vld1q_f64(wave_cut.get_unchecked(w_idx+4));
-            let w3 = vld1q_f64(wave_cut.get_unchecked(w_idx+6));
+            let w1 = vld1q_f64(wave_cut.get_unchecked(w_idx + 2));
+            let w2 = vld1q_f64(wave_cut.get_unchecked(w_idx + 4));
+            let w3 = vld1q_f64(wave_cut.get_unchecked(w_idx + 6));
             let s0 = vmulq_f64(w0, *sinc.get_unchecked(s_idx));
             let s1 = vmulq_f64(w1, *sinc.get_unchecked(s_idx + 1));
             let s2 = vmulq_f64(w2, *sinc.get_unchecked(s_idx + 2));
@@ -136,23 +136,39 @@ impl NeonSample for f64 {
         let packedsum0 = vaddq_f64(acc0, acc1);
         let packedsum1 = vaddq_f64(acc2, acc3);
         let packedsum2 = vaddq_f64(packedsum0, packedsum1);
-        let values = core::slice::from_raw_parts(&packedsum2 as *const _ as *const f64 , 2);
+        let values = core::slice::from_raw_parts(&packedsum2 as *const _ as *const f64, 2);
         values[0] + values[1]
     }
 }
 
 /// A SSE accelerated interpolator
-pub struct NeonInterpolator<T> where T: NeonSample {
+pub struct NeonInterpolator<T>
+where
+    T: NeonSample,
+{
     sincs: Vec<Vec<T::Sinc>>,
     length: usize,
     nbr_sincs: usize,
 }
 
-impl<T> SincInterpolator<T> for NeonInterpolator<T> where T: Sample {
+impl<T> SincInterpolator<T> for NeonInterpolator<T>
+where
+    T: Sample,
+{
     /// Calculate the scalar produt of an input wave and the selected sinc filter
     fn get_sinc_interpolated(&self, wave: &[T], index: usize, subindex: usize) -> T {
-        assert!((index + self.length) < wave.len(), "Tried to interpolate for index {}, max for the given input is {}", index, wave.len()-self.length-1);
-        assert!(subindex < self.nbr_sincs, "Tried to use sinc subindex {}, max is {}", subindex, self.nbr_sincs-1);
+        assert!(
+            (index + self.length) < wave.len(),
+            "Tried to interpolate for index {}, max for the given input is {}",
+            index,
+            wave.len() - self.length - 1
+        );
+        assert!(
+            subindex < self.nbr_sincs,
+            "Tried to use sinc subindex {}, max is {}",
+            subindex,
+            self.nbr_sincs - 1
+        );
         unsafe { T::get_sinc_interpolated_unsafe(wave, index, subindex, &self.sincs, self.length) }
     }
 
@@ -165,7 +181,10 @@ impl<T> SincInterpolator<T> for NeonInterpolator<T> where T: Sample {
     }
 }
 
-impl<T> NeonInterpolator<T> where T: Sample {
+impl<T> NeonInterpolator<T>
+where
+    T: Sample,
+{
     /// Create a new NeonInterpolator
     ///
     /// Parameters are:

--- a/src/interpolator_neon.rs
+++ b/src/interpolator_neon.rs
@@ -12,7 +12,7 @@ static FEATURES: &[CpuFeature] = &[CpuFeature::Neon];
 
 /// Trait governing what can be done with an NeonSample.
 pub trait NeonSample: Sized + Send {
-    type Sinc;
+    type Sinc: Send;
 
     /// Pack sincs into a vector.
     ///

--- a/src/interpolator_sse.rs
+++ b/src/interpolator_sse.rs
@@ -1,31 +1,35 @@
-use crate::windows::WindowFunction;
-use crate::sinc::make_sincs;
-use core::arch::x86_64::{__m128, __m128d};
-use core::arch::x86_64::{_mm_add_pd, _mm_hadd_pd, _mm_loadu_pd, _mm_mul_pd, _mm_setzero_pd, _mm_store_sd};
-use core::arch::x86_64::{_mm_add_ps, _mm_hadd_ps, _mm_loadu_ps, _mm_mul_ps, _mm_setzero_ps, _mm_store_ss};
 use crate::asynchro::SincInterpolator;
-use crate::error::{MissingCpuFeature, CpuFeature};
+use crate::error::{CpuFeature, MissingCpuFeature};
+use crate::sinc::make_sincs;
+use crate::windows::WindowFunction;
 use crate::Sample;
+use core::arch::x86_64::{__m128, __m128d};
+use core::arch::x86_64::{
+    _mm_add_pd, _mm_hadd_pd, _mm_loadu_pd, _mm_mul_pd, _mm_setzero_pd, _mm_store_sd,
+};
+use core::arch::x86_64::{
+    _mm_add_ps, _mm_hadd_ps, _mm_loadu_ps, _mm_mul_ps, _mm_setzero_ps, _mm_store_ss,
+};
 
 /// Collection of cpu features required for this interpolator.
 static FEATURES: &[CpuFeature] = &[CpuFeature::Sse3];
 
 /// Trait governing what can be done with an SseSample.
-pub trait SseSample: Sized {
-    type Sinc;
+pub trait SseSample: Sized + Send {
+    type Sinc: Send;
 
     /// Pack sincs into a vector.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// This is unsafe because it uses target_enable dispatching. There are no
     /// special requirements from the caller.
     unsafe fn pack_sincs(sincs: Vec<Vec<Self>>) -> Vec<Vec<Self::Sinc>>;
 
     /// Interpolate a sinc sample.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// The caller must ensure that the various indexes are not out of bounds
     /// in the collection of sincs.
     unsafe fn get_sinc_interpolated_unsafe(
@@ -147,17 +151,33 @@ impl SseSample for f64 {
 }
 
 /// A SSE accelerated interpolator
-pub struct SseInterpolator<T> where T: SseSample {
+pub struct SseInterpolator<T>
+where
+    T: SseSample,
+{
     sincs: Vec<Vec<T::Sinc>>,
     length: usize,
     nbr_sincs: usize,
 }
 
-impl<T> SincInterpolator<T> for SseInterpolator<T> where T: SseSample {
+impl<T> SincInterpolator<T> for SseInterpolator<T>
+where
+    T: SseSample,
+{
     /// Calculate the scalar produt of an input wave and the selected sinc filter
     fn get_sinc_interpolated(&self, wave: &[T], index: usize, subindex: usize) -> T {
-        assert!((index + self.length) < wave.len(), "Tried to interpolate for index {}, max for the given input is {}", index, wave.len()-self.length-1);
-        assert!(subindex < self.nbr_sincs, "Tried to use sinc subindex {}, max is {}", subindex, self.nbr_sincs-1);
+        assert!(
+            (index + self.length) < wave.len(),
+            "Tried to interpolate for index {}, max for the given input is {}",
+            index,
+            wave.len() - self.length - 1
+        );
+        assert!(
+            subindex < self.nbr_sincs,
+            "Tried to use sinc subindex {}, max is {}",
+            subindex,
+            self.nbr_sincs - 1
+        );
         unsafe { T::get_sinc_interpolated_unsafe(wave, index, subindex, &self.sincs, self.length) }
     }
 
@@ -170,7 +190,10 @@ impl<T> SincInterpolator<T> for SseInterpolator<T> where T: SseSample {
     }
 }
 
-impl<T> SseInterpolator<T> where T: Sample {
+impl<T> SseInterpolator<T>
+where
+    T: Sample,
+{
     /// Create a new SseInterpolator
     ///
     /// Parameters are:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ pub enum InterpolationType {
 
 /// A resampler that us used to resample a chunk of audio to a new sample rate.
 /// The rate can be adjusted as required.
-pub trait Resampler<T> {
+pub trait Resampler<T>: Send {
     /// Resample a chunk of audio.
     ///
     /// The input data is a slice, where each element of the slice is itself referenceable as a slice
@@ -221,7 +221,7 @@ pub trait Resampler<T> {
 /// let boxed: Box<dyn VecResampler<f64>> = Box::new(FftFixedIn::<f64>::new(44100, 88200, 1024, 2, 2));
 /// ```
 /// Use this implementation as an example if you need to fix the input type to something else.
-pub trait VecResampler<T> {
+pub trait VecResampler<T>: Send {
     /// Resample a chunk of audio.
     /// Input and output data is stored in vectors, where each element contains a vector with all samples for a single channel.
     fn process(&mut self, wave_in: &[Vec<T>]) -> ResampleResult<Vec<Vec<T>>>;

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -23,7 +23,8 @@ where
         + std::ops::AddAssign
         + AvxSample
         + SseSample
-        + NeonSample,
+        + NeonSample
+        + Send,
 {
     const PI: Self;
 


### PR DESCRIPTION
In a previous version SincFixedIn implemented Send and i could send it between threads. I guess that that constraint was lost when the trait was introduces.

I don't think there is anything that prevents the traits from being send we just have to declare it.

I may have sprinkled Send a bit too liberally in this pr 😅, tell me if you want me to change the pr in any way. 😀

My editor also ran cargo fmt on save :)