### PR TITLE
Fix more math for `FftFixedIn` max output length calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The `rubato` crate requires rustc version 1.61 or newer.
 
 ## Changelog
 
+- Unreleased
+  - Another bugfix for max output length calculation. 
 - v0.14.0
   - Add argument to let `input/output_buffer_allocate()` optionally pre-fill buffers with zeros.
   - Add convenience methods for managing buffers.


### PR DESCRIPTION
Commit a7ad2c146af9dbe9ac818a8fc4acc999d9d9fb93 fixed a problem where the maximum number of output frames was incorrect for a `FftFixedIn` resampler with an input sampling frequency of 44.1 kHz, an output sampling frequency of 40 kHz, a chunk size of 512, and 2 subchunks. However, in a production environment it was found that changing the input sampling frequency to 32728 Hz and the output sampling frequency to 32 kHz on the previously described resampler resulted in `output_frames_max` returning 0, which is blatantly incorrect.

My hypothesis about the root cause of the issue is that the aforementioned commit forgot to carry over the previous summand to prevent multiplying `chunk_size_in` by zero if `fft_size_in` is greater than `fft_size_out`. Now, a similar multiplication by zero can happen if `fft_size_in` is significantly larger than `chunk_size_in`.

To fix this issue, make sure that `fft_size_out` is always multiplied by a number greater than or equal to 1. Short of being able to produce any formal mathematical proof for the correctness of this change, I have checked by brute-force with a CUDA kernel that the required buffer length is never greater than the return value of `output_frames_max` after submitting 50 chunks for all combinations of [1, 48000] Hz sampling frequencies and [1, 8192] chunk sizes with 2 subchunks.

I have also added some unit tests to prevent numerical regressions in this calculation in the future, and to help catch this kind of bugs during development.