### PR TITLE
Use test_log::test to have env logging in all tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rand = "0.8.5"
 num-traits = "0.2.15"
 log = "0.4.18"
 approx = "0.5.1"
+test-log = "0.2.16"
 
 [[bench]]
 name = "resamplers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 [features]
 default = ["fft_resampler"]
 fft_resampler = ["realfft", "num-complex"]
+log = ["dep:log"]
 
 [dependencies]
 log = { version = "0.4.18", optional = true }

--- a/src/asynchro_fast.rs
+++ b/src/asynchro_fast.rs
@@ -816,6 +816,7 @@ mod tests {
     use crate::{check_output, check_ratio};
     use crate::{FastFixedIn, FastFixedOut};
     use rand::Rng;
+    use test_log::test;
 
     #[test]
     fn make_resampler_fi() {

--- a/src/asynchro_sinc.rs
+++ b/src/asynchro_sinc.rs
@@ -872,6 +872,7 @@ mod tests {
     use crate::{check_output, check_ratio};
     use crate::{SincFixedIn, SincFixedOut};
     use rand::Rng;
+    use test_log::test;
 
     fn basic_params() -> SincInterpolationParameters {
         SincInterpolationParameters {

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -68,6 +68,7 @@ mod tests {
     use crate::interpolation::get_nearest_times_2;
     use crate::interpolation::get_nearest_times_3;
     use crate::interpolation::get_nearest_times_4;
+    use test_log::test;
 
     #[test]
     fn get_nearest_2() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -703,6 +703,7 @@ pub mod tests {
     use crate::{FastFixedIn, PolynomialDegree, SincFixedIn, SincFixedOut};
     #[cfg(feature = "fft_resampler")]
     use crate::{FftFixedIn, FftFixedInOut, FftFixedOut};
+    use test_log::test;
 
     // This tests that a VecResampler can be boxed.
     #[test]

--- a/src/sinc.rs
+++ b/src/sinc.rs
@@ -53,6 +53,7 @@ where
 mod tests {
     use crate::sinc::make_sincs;
     use crate::WindowFunction;
+    use test_log::test;
 
     #[test]
     fn sincs() {

--- a/src/sinc_interpolator/mod.rs
+++ b/src/sinc_interpolator/mod.rs
@@ -160,6 +160,7 @@ mod tests {
     use crate::WindowFunction;
     use num_traits::Float;
     use rand::Rng;
+    use test_log::test;
 
     fn get_sinc_interpolated<T: Float>(wave: &[T], index: usize, sinc: &[T]) -> T {
         let wave_cut = &wave[index..(index + sinc.len())];

--- a/src/sinc_interpolator/sinc_interpolator_avx.rs
+++ b/src/sinc_interpolator/sinc_interpolator_avx.rs
@@ -219,6 +219,7 @@ mod tests {
     use crate::WindowFunction;
     use num_traits::Float;
     use rand::Rng;
+    use test_log::test;
 
     fn get_sinc_interpolated<T: Float>(wave: &[T], index: usize, sinc: &[T]) -> T {
         let wave_cut = &wave[index..(index + sinc.len())];

--- a/src/sinc_interpolator/sinc_interpolator_neon.rs
+++ b/src/sinc_interpolator/sinc_interpolator_neon.rs
@@ -223,6 +223,7 @@ mod tests {
     use crate::WindowFunction;
     use num_traits::Float;
     use rand::Rng;
+    use test_log::test;
 
     fn get_sinc_interpolated<T: Float>(wave: &[T], index: usize, sinc: &[T]) -> T {
         let wave_cut = &wave[index..(index + sinc.len())];

--- a/src/sinc_interpolator/sinc_interpolator_sse.rs
+++ b/src/sinc_interpolator/sinc_interpolator_sse.rs
@@ -231,6 +231,7 @@ mod tests {
     use crate::WindowFunction;
     use num_traits::Float;
     use rand::Rng;
+    use test_log::test;
 
     fn get_sinc_interpolated<T: Float>(wave: &[T], index: usize, sinc: &[T]) -> T {
         let wave_cut = &wave[index..(index + sinc.len())];

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -687,6 +687,7 @@ mod tests {
     use crate::synchro::{FftFixedIn, FftFixedInOut, FftFixedOut, FftResampler};
     use crate::Resampler;
     use rand::Rng;
+    use test_log::test;
 
     #[test]
     fn resample_unit() {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -157,6 +157,7 @@ mod tests {
     use crate::windows::make_window;
     use crate::windows::WindowFunction;
     use approx::assert_abs_diff_eq;
+    use test_log::test;
 
     #[test]
     fn test_blackman_harris() {


### PR DESCRIPTION
To enable logging in tests one can now simply use the `RUST_LOG=trace` environment variable.

Example:
```
RUST_LOG=trace cargo test --features log
```

Also added the log feature to Cargo.toml, i think it's cleaner to list all features explicitly.