### PR TITLE
Draft: Allow lowering the chunk_size on Resampler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 [features]
 default = ["fft_resampler"]
 fft_resampler = ["realfft", "num-complex"]
+log = ["dep:log"]
 
 [dependencies]
 log = { version = "0.4.18", optional = true }
@@ -30,6 +31,7 @@ criterion = "0.5.1"
 rand = "0.8.5"
 num-traits = "0.2.15"
 log = "0.4.18"
+test-log = "0.2.16"
 approx = "0.5.1"
 
 [[bench]]

--- a/src/asynchro_fast.rs
+++ b/src/asynchro_fast.rs
@@ -500,6 +500,105 @@ where
         self.resample_ratio = self.resample_ratio_original;
         self.target_ratio = self.resample_ratio_original;
     }
+
+    fn set_chunk_size(&mut self, chunk_size: usize) -> ResampleResult<()> {
+        todo!()
+    }
+
+    fn chunk_size(&self) -> usize {
+        todo!()
+    }
+
+    fn max_chunk_size(&self) -> usize {
+        todo!()
+    }
+
+    fn process<V: AsRef<[T]>>(
+        &mut self,
+        wave_in: &[V],
+        active_channels_mask: Option<&[bool]>,
+    ) -> ResampleResult<Vec<Vec<T>>> {
+        let frames = self.output_frames_next();
+        let channels = self.nbr_channels();
+        let mut wave_out = Vec::with_capacity(channels);
+        for chan in 0..channels {
+            let chan_out = if active_channels_mask.map(|mask| mask[chan]).unwrap_or(true) {
+                vec![T::zero(); frames]
+            } else {
+                vec![]
+            };
+            wave_out.push(chan_out);
+        }
+        let (_, out_len) =
+            self.process_into_buffer(wave_in, &mut wave_out, active_channels_mask)?;
+        for chan_out in wave_out.iter_mut() {
+            chan_out.truncate(out_len);
+        }
+        Ok(wave_out)
+    }
+
+    fn process_partial_into_buffer<Vin: AsRef<[T]>, Vout: AsMut<[T]>>(
+        &mut self,
+        wave_in: Option<&[Vin]>,
+        wave_out: &mut [Vout],
+        active_channels_mask: Option<&[bool]>,
+    ) -> ResampleResult<(usize, usize)> {
+        let frames = self.input_frames_next();
+        let mut wave_in_padded = Vec::with_capacity(self.nbr_channels());
+        for _ in 0..self.nbr_channels() {
+            wave_in_padded.push(vec![T::zero(); frames]);
+        }
+        if let Some(input) = wave_in {
+            for (ch_input, ch_padded) in input.iter().zip(wave_in_padded.iter_mut()) {
+                let mut frames_in = ch_input.as_ref().len();
+                if frames_in > frames {
+                    frames_in = frames;
+                }
+                if frames_in > 0 {
+                    ch_padded[..frames_in].copy_from_slice(&ch_input.as_ref()[..frames_in]);
+                } else {
+                    ch_padded.clear();
+                }
+            }
+        }
+        self.process_into_buffer(&wave_in_padded, wave_out, active_channels_mask)
+    }
+
+    fn process_partial<V: AsRef<[T]>>(
+        &mut self,
+        wave_in: Option<&[V]>,
+        active_channels_mask: Option<&[bool]>,
+    ) -> ResampleResult<Vec<Vec<T>>> {
+        let frames = self.output_frames_next();
+        let channels = self.nbr_channels();
+        let mut wave_out = Vec::with_capacity(channels);
+        for chan in 0..channels {
+            let chan_out = if active_channels_mask.map(|mask| mask[chan]).unwrap_or(true) {
+                vec![T::zero(); frames]
+            } else {
+                vec![]
+            };
+            wave_out.push(chan_out);
+        }
+        let (_, out_len) =
+            self.process_partial_into_buffer(wave_in, &mut wave_out, active_channels_mask)?;
+        for chan_out in wave_out.iter_mut() {
+            chan_out.truncate(out_len);
+        }
+        Ok(wave_out)
+    }
+
+    fn input_buffer_allocate(&self, filled: bool) -> Vec<Vec<T>> {
+        let frames = self.input_frames_max();
+        let channels = self.nbr_channels();
+        crate::make_buffer(channels, frames, filled)
+    }
+
+    fn output_buffer_allocate(&self, filled: bool) -> Vec<Vec<T>> {
+        let frames = self.output_frames_max();
+        let channels = self.nbr_channels();
+        crate::make_buffer(channels, frames, filled)
+    }
 }
 
 impl<T> FastFixedOut<T>
@@ -806,6 +905,105 @@ where
         self.channel_mask.iter_mut().for_each(|val| *val = true);
         self.resample_ratio = self.resample_ratio_original;
         self.target_ratio = self.resample_ratio_original;
+    }
+
+    fn set_chunk_size(&mut self, chunk_size: usize) -> ResampleResult<()> {
+        todo!()
+    }
+
+    fn chunk_size(&self) -> usize {
+        todo!()
+    }
+
+    fn max_chunk_size(&self) -> usize {
+        todo!()
+    }
+
+    fn process<V: AsRef<[T]>>(
+        &mut self,
+        wave_in: &[V],
+        active_channels_mask: Option<&[bool]>,
+    ) -> ResampleResult<Vec<Vec<T>>> {
+        let frames = self.output_frames_next();
+        let channels = self.nbr_channels();
+        let mut wave_out = Vec::with_capacity(channels);
+        for chan in 0..channels {
+            let chan_out = if active_channels_mask.map(|mask| mask[chan]).unwrap_or(true) {
+                vec![T::zero(); frames]
+            } else {
+                vec![]
+            };
+            wave_out.push(chan_out);
+        }
+        let (_, out_len) =
+            self.process_into_buffer(wave_in, &mut wave_out, active_channels_mask)?;
+        for chan_out in wave_out.iter_mut() {
+            chan_out.truncate(out_len);
+        }
+        Ok(wave_out)
+    }
+
+    fn process_partial_into_buffer<Vin: AsRef<[T]>, Vout: AsMut<[T]>>(
+        &mut self,
+        wave_in: Option<&[Vin]>,
+        wave_out: &mut [Vout],
+        active_channels_mask: Option<&[bool]>,
+    ) -> ResampleResult<(usize, usize)> {
+        let frames = self.input_frames_next();
+        let mut wave_in_padded = Vec::with_capacity(self.nbr_channels());
+        for _ in 0..self.nbr_channels() {
+            wave_in_padded.push(vec![T::zero(); frames]);
+        }
+        if let Some(input) = wave_in {
+            for (ch_input, ch_padded) in input.iter().zip(wave_in_padded.iter_mut()) {
+                let mut frames_in = ch_input.as_ref().len();
+                if frames_in > frames {
+                    frames_in = frames;
+                }
+                if frames_in > 0 {
+                    ch_padded[..frames_in].copy_from_slice(&ch_input.as_ref()[..frames_in]);
+                } else {
+                    ch_padded.clear();
+                }
+            }
+        }
+        self.process_into_buffer(&wave_in_padded, wave_out, active_channels_mask)
+    }
+
+    fn process_partial<V: AsRef<[T]>>(
+        &mut self,
+        wave_in: Option<&[V]>,
+        active_channels_mask: Option<&[bool]>,
+    ) -> ResampleResult<Vec<Vec<T>>> {
+        let frames = self.output_frames_next();
+        let channels = self.nbr_channels();
+        let mut wave_out = Vec::with_capacity(channels);
+        for chan in 0..channels {
+            let chan_out = if active_channels_mask.map(|mask| mask[chan]).unwrap_or(true) {
+                vec![T::zero(); frames]
+            } else {
+                vec![]
+            };
+            wave_out.push(chan_out);
+        }
+        let (_, out_len) =
+            self.process_partial_into_buffer(wave_in, &mut wave_out, active_channels_mask)?;
+        for chan_out in wave_out.iter_mut() {
+            chan_out.truncate(out_len);
+        }
+        Ok(wave_out)
+    }
+
+    fn input_buffer_allocate(&self, filled: bool) -> Vec<Vec<T>> {
+        let frames = self.input_frames_max();
+        let channels = self.nbr_channels();
+        crate::make_buffer(channels, frames, filled)
+    }
+
+    fn output_buffer_allocate(&self, filled: bool) -> Vec<Vec<T>> {
+        let frames = self.output_frames_max();
+        let channels = self.nbr_channels();
+        crate::make_buffer(channels, frames, filled)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,10 @@ where
     /// For synchronous resamplers, this will always return [ResampleError::SyncNotAdjustable].
     fn set_resample_ratio_relative(&mut self, rel_ratio: f64, ramp: bool) -> ResampleResult<()>;
 
+    fn set_chunk_size(&mut self, chunk_size: usize) -> ResampleResult<()>;
+    fn chunk_size(&self) -> usize;
+    fn max_chunk_size(&self) -> usize;
+
     /// Reset the resampler state and clear all internal buffers.
     fn reset(&mut self);
 }


### PR DESCRIPTION
ATTENTION: This is just me playing around with the codebase, i have no idea of the math ^^

This extends the Resampler trait with:

 - `fn set_chunk_size(&mut self, chunk_size: usize) -> ResampleResult<()>;`
 - `fn chunk_size(&self) -> usize;`
 - `fn max_chunk_size(&self) -> usize;`

ToDo:
- [ ] Currently this calculated an invalid needed_length after the first processed frame
- [ ] Rebase on top of https://github.com/HEnquist/rubato/pull/80
- [ ] Remove weird default implementations