### PR TITLE
Test to eliminate the margin in output_frames_next()

### DIFF
--- a/src/asynchro_fast.rs
+++ b/src/asynchro_fast.rs
@@ -257,10 +257,7 @@ where
             update_mask_from_buffers(&mut self.channel_mask);
         };
 
-        // Set length to chunksize*ratio plus a safety margin of 10 elements.
-        let needed_len = (self.chunk_size as f64
-            * (0.5 * self.resample_ratio + 0.5 * self.target_ratio)
-            + 10.0) as usize;
+        let needed_len = self.output_frames_next();
 
         validate_buffers(
             wave_in,

--- a/src/asynchro_fast.rs
+++ b/src/asynchro_fast.rs
@@ -447,8 +447,7 @@ where
     }
 
     fn output_frames_next(&self) -> usize {
-        (self.chunk_size as f64 * (0.5 * self.resample_ratio + 0.5 * self.target_ratio) + 10.0)
-            as usize
+        (self.chunk_size as f64 * (0.5 * self.resample_ratio + 0.5 * self.target_ratio)) as usize
     }
 
     fn output_delay(&self) -> usize {

--- a/src/asynchro_sinc.rs
+++ b/src/asynchro_sinc.rs
@@ -484,8 +484,7 @@ where
     }
 
     fn output_frames_next(&self) -> usize {
-        (self.chunk_size as f64 * (0.5 * self.resample_ratio + 0.5 * self.target_ratio) + 10.0)
-            as usize
+        (self.chunk_size as f64 * (0.5 * self.resample_ratio + 0.5 * self.target_ratio)) as usize
     }
 
     fn output_delay(&self) -> usize {

--- a/src/asynchro_sinc.rs
+++ b/src/asynchro_sinc.rs
@@ -322,10 +322,7 @@ where
             update_mask_from_buffers(&mut self.channel_mask);
         };
 
-        // Set length to chunksize*ratio plus a safety margin of 10 elements.
-        let needed_len = (self.chunk_size as f64
-            * (0.5 * self.resample_ratio + 0.5 * self.target_ratio)
-            + 10.0) as usize;
+        let needed_len = self.output_frames_next();
 
         validate_buffers(
             wave_in,


### PR DESCRIPTION
This is not yet available for review.  

I wondered about the inclusion of margins in output_frames_next() as described in Issue https://github.com/HEnquist/rubato/issues/88. I tried to check what would happen if the margin was removed.

This fails the test.
Also, adding a 1 frame margin passes the test, but the reason for this is not yet clear.