### PR TITLE
Add `Resampler::process_all`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,94 @@ where
         Ok(wave_out)
     }
 
+    // This is a convenience wrapper to perform a complete resampling
+    // operation. It should be called on a newly-constructed `Resampler`, or
+    // one which has just been reset.
+    //
+    // It calls `Resampler::process_into_buffer` as-needed to process all input
+    // chunks, as well as to squeeze any remaining internally-buffered chunks
+    // out of the resampler.
+    //
+    // Both initial delay samples and excess final samples are trimmed from the
+    // output.
+    //
+    // `resample_ratio` is `new_sample_rate / old_sample_rate`
+    fn process_all<V: AsRef<[T]>>(
+        &mut self,
+        wave_in: &[V],
+        active_channels_mask: Option<&[bool]>,
+        resample_ratio: f64,
+    ) -> ResampleResult<Vec<Vec<T>>> {
+        if wave_in.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let new_length = (wave_in[0].as_ref().len() as f64 * resample_ratio) as usize;
+
+        let mut output = vec![Vec::<T>::with_capacity(new_length); wave_in.len()];
+
+        let mut input_buffer = (0..wave_in.len())
+            .map(|channel| wave_in[channel].as_ref())
+            .collect::<Vec<&[T]>>();
+
+        let mut output_buffer = self.output_buffer_allocate(true);
+
+        let delay = self.output_delay();
+
+        let mut total = 0;
+
+        let mut append =
+            |output_channels: &mut [Vec<T>], output_buffer: &[Vec<T>], produced: usize| {
+                // skip samples up to delay
+                let skip = delay.saturating_sub(total).min(produced);
+                for (output, buffer) in output_channels.iter_mut().zip(output_buffer) {
+                    output.extend_from_slice(&buffer[skip..produced]);
+                }
+                total += produced;
+            };
+
+        while input_buffer[0].len() >= self.input_frames_next() {
+            let (consumed, produced) =
+                self.process_into_buffer(&input_buffer, &mut output_buffer, active_channels_mask)?;
+
+            for channel in &mut input_buffer {
+                *channel = &channel[consumed..];
+            }
+
+            append(&mut output, &output_buffer, produced);
+        }
+
+        if !input_buffer[0].is_empty() {
+            let (_consumed, produced) = self.process_partial_into_buffer(
+                Some(&input_buffer),
+                &mut output_buffer,
+                active_channels_mask,
+            )?;
+
+            append(&mut output, &output_buffer, produced);
+        }
+
+        while output[0].len() < new_length {
+            let (_consumed, produced) = self.process_partial_into_buffer(
+                None::<&[V]>,
+                &mut output_buffer,
+                active_channels_mask,
+            )?;
+
+            append(&mut output, &output_buffer, produced);
+
+            if produced == 0 {
+                break;
+            }
+        }
+
+        for channel in &mut output {
+            channel.truncate(new_length);
+        }
+
+        Ok(output)
+    }
+
     /// Resample a buffer of audio to a pre-allocated output buffer.
     /// Use this in real-time applications where the unpredictable time required to allocate
     /// memory from the heap can cause glitches. If this is not a problem, you may use


### PR DESCRIPTION
This PR adds `Resampler::process_all`, a convenience method to perform a complete resample operation on an input.

Using a `rubato::Resampler` is pretty involved, so I think it would be helpful to have a helper method which performs a complete resampling operation.

This is opened as a draft, since there are definitely still some issues and open questions:
- This needs tests. If you think this is a useful addition which could be merged, I can definitely write some.
- Passing the `resample_ratio` seems unfortunate. Perhaps `Resampler` should get a required `Resampler::resample_ratio` method which returns the current resample ratio?
- I don't check whether the channels in `wave_in: &[V]` are all the same length, but from looking at other code, I couldn't tell whether this was something I should check, or something which it is assumed that the user is responsible for.