### PR TITLE
Re-export audioadapter crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 
 #[cfg(feature = "log")]
 extern crate log;
+
+pub use audioadapter;
+
 use audioadapter::{Adapter, AdapterMut};
 use audioadapter_buffers::owned::InterleavedOwned;
 


### PR DESCRIPTION
Since the `audioadapter` crate is part of the public interface of `rubato`, re-export it, so users don't need to add an additional dependency on `audioadapter`, which has to be kept in sync with the version used by `rubato`.