### PR TITLE
Fix clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,7 +386,7 @@ pub mod tests {
     #[test_log::test]
     fn process_all() {
         let mut resampler = Async::<f64>::new_sinc(
-            88200 as f64 / 44100 as f64,
+            88200.0 / 44100.0,
             1.1,
             &SincInterpolationParameters {
                 sinc_len: 64,
@@ -447,7 +447,7 @@ pub mod tests {
     fn boxed_resampler() {
         let mut boxed: Box<dyn Resampler<f64>> = Box::new(
             Async::<f64>::new_sinc(
-                88200 as f64 / 44100 as f64,
+                88200.0 / 44100.0,
                 1.1,
                 &SincInterpolationParameters {
                     sinc_len: 64,
@@ -468,7 +468,7 @@ pub mod tests {
         let mut waves_out = vec![vec![0.0f64; max_frames_out]; 2];
         let input = SequentialSliceOfVecs::new(&waves, 2, nbr_frames_in_next).unwrap();
         let mut output = SequentialSliceOfVecs::new_mut(&mut waves_out, 2, max_frames_out).unwrap();
-        let _ = process_with_boxed(&mut boxed, &input, &mut output);
+        process_with_boxed(&mut boxed, &input, &mut output);
     }
 
     fn process_with_boxed<'a>(
@@ -527,7 +527,7 @@ pub mod tests {
                     for ch in 0..2 {
                         input_data[ch][m] = ramp_value;
                     }
-                    ramp_value = ramp_value + 0.1;
+                    ramp_value += 0.1;
                 }
                 let input = SequentialSliceOfVecs::new(&input_data, 2, expected_frames_in).unwrap();
                 let mut output_data = vec![vec![0.0 as $fty; expected_frames_out]; 2];

--- a/src/sinc_interpolator/mod.rs
+++ b/src/sinc_interpolator/mod.rs
@@ -175,7 +175,7 @@ mod tests {
             wave.push(rng.gen::<f64>());
         }
         let sinc_len = 256;
-        let f_cutoff = 0.9473371669037001;
+        let f_cutoff = 0.94733715;
         let oversampling_factor = 256;
         let window = WindowFunction::BlackmanHarris2;
 
@@ -194,7 +194,7 @@ mod tests {
             wave.push(rng.gen::<f32>());
         }
         let sinc_len = 256;
-        let f_cutoff = 0.9473371669037001;
+        let f_cutoff = 0.94733715;
         let oversampling_factor = 256;
         let window = WindowFunction::BlackmanHarris2;
 

--- a/src/sinc_interpolator/sinc_interpolator_neon.rs
+++ b/src/sinc_interpolator/sinc_interpolator_neon.rs
@@ -242,7 +242,7 @@ mod tests {
             wave.push(rng.gen::<f64>());
         }
         let sinc_len = 256;
-        let f_cutoff = 0.9473371669037001;
+        let f_cutoff = 0.94733715;
         let oversampling_factor = 256;
         let window = WindowFunction::BlackmanHarris2;
         let sincs = make_sincs::<f64>(sinc_len, oversampling_factor, f_cutoff, window);
@@ -261,7 +261,7 @@ mod tests {
             wave.push(rng.gen::<f32>());
         }
         let sinc_len = 256;
-        let f_cutoff = 0.9473371669037001;
+        let f_cutoff = 0.94733715;
         let oversampling_factor = 256;
         let window = WindowFunction::BlackmanHarris2;
         let sincs = make_sincs::<f32>(sinc_len, oversampling_factor, f_cutoff, window);

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -664,7 +664,7 @@ mod tests {
         let mut overlap = vec![0.0; 1000];
         resampler.resample_unit(&wave_in, &mut wave_out, &mut overlap);
         let vecsum = wave_out.iter().sum::<f64>();
-        let maxval = wave_out.iter().cloned().fold(0. / 0., f64::max);
+        let maxval = wave_out.iter().cloned().fold(f64::NAN, f64::max);
         assert!((vecsum - 4.0 * 1000.0 / 147.0).abs() < 1.0e-6);
         assert!((maxval - 1.0).abs() < 0.1);
     }


### PR DESCRIPTION
The shorter floating point literals are because the previous ones had excessive precision that couldn't be preserved in an f32.