### PR TITLE
Split Resampler into capability traits Adjustable and Resizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,9 @@ RUST_LOG=trace cargo test --features log
 ## Example
 
 Resample a dummy audio file from 44100 to 48000 Hz.
+This uses the `Fft` resampler, which requires the `fft_resampler` feature (enabled by default).
 See also the "process_f64" example that can be used to process a file from disk.
-```rust
+```rust,ignore
 use rubato::{
     Resampler, Fft, FixedSync, Indexing
 };

--- a/README.md
+++ b/README.md
@@ -412,7 +412,8 @@ let r = Fft::<f64>::new_custom(rate_in, rate_out, chunk_size, sub_chunks, channe
 `set_resample_ratio_relative` are now on the `Adjustable` trait, and `set_chunk_size` is on
 `Resizable`. On a concrete resampler, just bring the trait into scope. On a `dyn Resampler`,
 recover the capability with `as_adjustable()` / `as_resizable()` (this replaces the old
-`SyncNotAdjustable` / `ChunkSizeNotAdjustable` errors, which are removed).
+`SyncNotAdjustable` / `ChunkSizeNotAdjustable` errors, which are removed). To query the
+capability through a shared `&dyn Resampler`, use `is_adjustable()` / `is_resizable()`.
 
 ```rust,ignore
 // before: on a Box<dyn Resampler>, with a runtime error for synchronous resamplers
@@ -464,7 +465,8 @@ async_resampler.set_resample_ratio_relative(0.95, true)?;
   - Split the capability-specific methods out of `Resampler` into the `Adjustable` trait
     (`set_resample_ratio`, `set_resample_ratio_relative`) and the `Resizable` trait
     (`set_chunk_size`). `Resampler` gains `as_adjustable()` and `as_resizable()` to recover
-    these capabilities from a trait object. The `SyncNotAdjustable` and `ChunkSizeNotAdjustable`
+    these capabilities from a trait object, and `is_adjustable()` / `is_resizable()` to query
+    them through a shared reference. The `SyncNotAdjustable` and `ChunkSizeNotAdjustable`
     error variants are removed, since calling these methods is now a compile-time capability.
 - v3.0.0
   - Use separate lifetimes for `buffer_in` and `buffer_out` in `process_into_buffer`.

--- a/README.md
+++ b/README.md
@@ -408,6 +408,27 @@ let r = Fft::<f64>::new_custom(rate_in, rate_out, chunk_size, sub_chunks, channe
     WindowFunction::BlackmanHarris2, fixed)?;
 ```
 
+**Ratio and chunk-size changes moved to capability traits.** `set_resample_ratio`,
+`set_resample_ratio_relative` are now on the `Adjustable` trait, and `set_chunk_size` is on
+`Resizable`. On a concrete resampler, just bring the trait into scope. On a `dyn Resampler`,
+recover the capability with `as_adjustable()` / `as_resizable()` (this replaces the old
+`SyncNotAdjustable` / `ChunkSizeNotAdjustable` errors, which are removed).
+
+```rust,ignore
+// before: on a Box<dyn Resampler>, with a runtime error for synchronous resamplers
+resampler.set_resample_ratio(new_ratio, true)?;
+// after: None means "synchronous, nothing to adjust"
+if let Some(adjustable) = resampler.as_adjustable() {
+    adjustable.set_resample_ratio(new_ratio, true)?;
+}
+
+// before: on a concrete Async resampler
+async_resampler.set_resample_ratio_relative(0.95, true)?;
+// after: same call, but the Adjustable trait must be in scope
+use rubato::Adjustable;
+async_resampler.set_resample_ratio_relative(0.95, true)?;
+```
+
 **The error enums are now `#[non_exhaustive]`.** If you `match` on `ResampleError` or
 `ResamplerConstructionError`, add a `_ => ...` arm.
 
@@ -440,6 +461,11 @@ let r = Fft::<f64>::new_custom(rate_in, rate_out, chunk_size, sub_chunks, channe
     `SincInterpolationType`, `PolynomialDegree`, `FixedSync` and `FixedAsync`.
   - Return `WrongNumberOfMaskChannels` instead of panicking when the
     `active_channels_mask` passed to a process method has the wrong length.
+  - Split the capability-specific methods out of `Resampler` into the `Adjustable` trait
+    (`set_resample_ratio`, `set_resample_ratio_relative`) and the `Resizable` trait
+    (`set_chunk_size`). `Resampler` gains `as_adjustable()` and `as_resizable()` to recover
+    these capabilities from a trait object. The `SyncNotAdjustable` and `ChunkSizeNotAdjustable`
+    error variants are removed, since calling these methods is now a compile-time capability.
 - v3.0.0
   - Use separate lifetimes for `buffer_in` and `buffer_out` in `process_into_buffer`.
   - Improve sinc resampler performance with smarter dot product calculation.

--- a/examples/fixedout_ramp64.rs
+++ b/examples/fixedout_ramp64.rs
@@ -1,8 +1,8 @@
 extern crate rubato;
 use audioadapter_buffers::direct::InterleavedSlice;
 use rubato::{
-    Async, FixedAsync, Indexing, Resampler, SincInterpolationParameters, SincInterpolationType,
-    WindowFunction,
+    Adjustable, Async, FixedAsync, Indexing, Resampler, SincInterpolationParameters,
+    SincInterpolationType, WindowFunction,
 };
 use std::convert::TryInto;
 use std::env;

--- a/examples/polyfixedin_ramp64.rs
+++ b/examples/polyfixedin_ramp64.rs
@@ -1,6 +1,6 @@
 extern crate rubato;
 use audioadapter_buffers::direct::InterleavedSlice;
-use rubato::{Async, FixedAsync, Indexing, PolynomialDegree, Resampler};
+use rubato::{Adjustable, Async, FixedAsync, Indexing, PolynomialDegree, Resampler};
 use std::convert::TryInto;
 use std::env;
 use std::fs::File;

--- a/src/asynchro.rs
+++ b/src/asynchro.rs
@@ -11,7 +11,7 @@ use crate::sinc_interpolator::{
     AnyInterpolator, AvxSample, NeonSample, SincInterpolator, SseSample,
 };
 use crate::{get_offsets, get_partial_len, update_mask, Indexing};
-use crate::{validate_buffers, Resampler, Sample};
+use crate::{validate_buffers, Adjustable, Resampler, Resizable, Sample};
 
 /// An enum for specifying which side of an asynchronous resampler should be fixed size.
 /// This is similar to [FixedSync](crate::FixedSync) that is used for the synchronous resamplers.
@@ -155,7 +155,7 @@ where
     ///
     /// Parameters are:
     /// - `resample_ratio`: Starting ratio between output and input sample rates, must be > 0.
-    /// - `max_resample_ratio_relative`: Maximum ratio that can be set with [Resampler::set_resample_ratio] relative to `resample_ratio`, must be >= 1.0. The minimum relative ratio is the reciprocal of the maximum. For example, with `max_resample_ratio_relative` of 10.0, the ratio can be set between `resample_ratio * 10.0` and `resample_ratio / 10.0`.
+    /// - `max_resample_ratio_relative`: Maximum ratio that can be set with [Adjustable::set_resample_ratio](crate::Adjustable::set_resample_ratio) relative to `resample_ratio`, must be >= 1.0. The minimum relative ratio is the reciprocal of the maximum. For example, with `max_resample_ratio_relative` of 10.0, the ratio can be set between `resample_ratio * 10.0` and `resample_ratio / 10.0`.
     /// - `interpolation_type`: Degree of polynomial used for interpolation, see [PolynomialDegree].
     /// - `chunk_size`: Size of input data in frames.
     /// - `nbr_channels`: Number of channels in input/output.
@@ -237,7 +237,7 @@ where
     ///
     /// Parameters are:
     /// - `resample_ratio`: Starting ratio between output and input sample rates, must be > 0.
-    /// - `max_resample_ratio_relative`: Maximum ratio that can be set with [Resampler::set_resample_ratio] relative to `resample_ratio`, must be >= 1.0. The minimum relative ratio is the reciprocal of the maximum. For example, with `max_resample_ratio_relative` of 10.0, the ratio can be set between `resample_ratio * 10.0` and `resample_ratio / 10.0`.
+    /// - `max_resample_ratio_relative`: Maximum ratio that can be set with [Adjustable::set_resample_ratio](crate::Adjustable::set_resample_ratio) relative to `resample_ratio`, must be >= 1.0. The minimum relative ratio is the reciprocal of the maximum. For example, with `max_resample_ratio_relative` of 10.0, the ratio can be set between `resample_ratio * 10.0` and `resample_ratio / 10.0`.
     /// - `parameters`: Parameters for interpolation, see [SincInterpolationParameters].
     /// - `chunk_size`: Size of input data in frames.
     /// - `nbr_channels`: Number of channels in input/output.
@@ -277,7 +277,7 @@ where
     ///
     /// Parameters are:
     /// - `resample_ratio`: Starting ratio between output and input sample rates, must be > 0.
-    /// - `max_resample_ratio_relative`: Maximum ratio that can be set with [Resampler::set_resample_ratio] relative to `resample_ratio`, must be >= 1.0. The minimum relative ratio is the reciprocal of the maximum. For example, with `max_resample_ratio_relative` of 10.0, the ratio can be set between `resample_ratio` * 10.0 and `resample_ratio` / 10.0.
+    /// - `max_resample_ratio_relative`: Maximum ratio that can be set with [Adjustable::set_resample_ratio](crate::Adjustable::set_resample_ratio) relative to `resample_ratio`, must be >= 1.0. The minimum relative ratio is the reciprocal of the maximum. For example, with `max_resample_ratio_relative` of 10.0, the ratio can be set between `resample_ratio` * 10.0 and `resample_ratio` / 10.0.
     /// - `interpolation_type`: Parameters for interpolation, see `SincInterpolationParameters`.
     /// - `interpolator`: The interpolator to use.
     /// - `chunk_size`: Size of output data in frames.
@@ -573,6 +573,35 @@ where
         self.needed_input_size
     }
 
+    fn resample_ratio(&self) -> f64 {
+        self.resample_ratio
+    }
+
+    fn reset(&mut self) {
+        self.buffer
+            .iter_mut()
+            .for_each(|ch| ch.iter_mut().for_each(|s| *s = T::zero()));
+        self.channel_mask.iter_mut().for_each(|val| *val = true);
+        self.last_index = self.inner_resampler.init_last_index();
+        self.resample_ratio = self.resample_ratio_original;
+        self.target_ratio = self.resample_ratio_original;
+        self.chunk_size = self.max_chunk_size;
+        self.update_lengths();
+    }
+
+    fn as_adjustable(&mut self) -> Option<&mut dyn Adjustable<T>> {
+        Some(self)
+    }
+
+    fn as_resizable(&mut self) -> Option<&mut dyn Resizable<T>> {
+        Some(self)
+    }
+}
+
+impl<T> Adjustable<T> for Async<T>
+where
+    T: Sample,
+{
     fn set_resample_ratio(&mut self, new_ratio: f64, ramp: bool) -> ResampleResult<()> {
         trace!("Change resample ratio to {}", new_ratio);
         if (new_ratio / self.resample_ratio_original >= 1.0 / self.max_relative_ratio)
@@ -593,27 +622,16 @@ where
         }
     }
 
-    fn resample_ratio(&self) -> f64 {
-        self.resample_ratio
-    }
-
     fn set_resample_ratio_relative(&mut self, rel_ratio: f64, ramp: bool) -> ResampleResult<()> {
         let new_ratio = self.resample_ratio_original * rel_ratio;
         self.set_resample_ratio(new_ratio, ramp)
     }
+}
 
-    fn reset(&mut self) {
-        self.buffer
-            .iter_mut()
-            .for_each(|ch| ch.iter_mut().for_each(|s| *s = T::zero()));
-        self.channel_mask.iter_mut().for_each(|val| *val = true);
-        self.last_index = self.inner_resampler.init_last_index();
-        self.resample_ratio = self.resample_ratio_original;
-        self.target_ratio = self.resample_ratio_original;
-        self.chunk_size = self.max_chunk_size;
-        self.update_lengths();
-    }
-
+impl<T> Resizable<T> for Async<T>
+where
+    T: Sample,
+{
     fn set_chunk_size(&mut self, chunksize: usize) -> ResampleResult<()> {
         if chunksize > self.max_chunk_size || chunksize == 0 {
             return Err(ResampleError::InvalidChunkSize {
@@ -632,7 +650,6 @@ mod tests {
     use crate::tests::expected_output_value;
     use crate::Indexing;
     use crate::PolynomialDegree;
-    use crate::Resampler;
     use crate::SincInterpolationParameters;
     use crate::SincInterpolationType;
     use crate::WindowFunction;
@@ -640,6 +657,7 @@ mod tests {
         assert_fi_len, assert_fo_len, check_input_offset, check_masked, check_output,
         check_output_offset, check_ratio, check_reset,
     };
+    use crate::{Adjustable, Resampler, Resizable};
     use crate::{Async, FixedAsync};
     use audioadapter_buffers::direct::SequentialSliceOfVecs;
     use test_case::test_matrix;

--- a/src/asynchro.rs
+++ b/src/asynchro.rs
@@ -55,8 +55,8 @@ pub trait InnerResampler<T>: Send {
 /// and when output size is fixed, the input size varies.
 ///
 /// The number of frames on the fixed side is determined by the chunk size argument to the constructor.
-/// This value can be changed by the `set_chunk_size()` method,
-/// to let the resampler process smaller chunks of audio data.
+/// This value can be changed by the [set_chunk_size](Resizable::set_chunk_size) method of the
+/// [Resizable] trait (which must be in scope), to let the resampler process smaller chunks of audio data.
 /// Note that the chunk size cannot exceed the value given at creation time.
 ///
 /// When the input size is fixed, the maximum value can be retrieved using the `input_size_max()` method,
@@ -441,6 +441,23 @@ where
             self.needed_output_size
         );
     }
+
+    /// Check whether a ratio, expressed relative to the original ratio, is within the
+    /// allowed `1 / max` to `max` range. Checking the relative ratio directly avoids the
+    /// rounding error that a `(original * rel) / original` round-trip would introduce at
+    /// the exact bounds.
+    fn relative_ratio_in_bounds(&self, rel_ratio: f64) -> bool {
+        rel_ratio >= 1.0 / self.max_relative_ratio && rel_ratio <= self.max_relative_ratio
+    }
+
+    /// Apply an already validated resample ratio to the internal state.
+    fn apply_ratio(&mut self, new_ratio: f64, ramp: bool) {
+        if !ramp {
+            self.resample_ratio = new_ratio;
+        }
+        self.target_ratio = new_ratio;
+        self.update_lengths();
+    }
 }
 
 impl<T> Resampler<T> for Async<T>
@@ -593,8 +610,16 @@ where
         Some(self)
     }
 
+    fn is_adjustable(&self) -> bool {
+        true
+    }
+
     fn as_resizable(&mut self) -> Option<&mut dyn Resizable<T>> {
         Some(self)
+    }
+
+    fn is_resizable(&self) -> bool {
+        true
     }
 }
 
@@ -604,14 +629,8 @@ where
 {
     fn set_resample_ratio(&mut self, new_ratio: f64, ramp: bool) -> ResampleResult<()> {
         trace!("Change resample ratio to {}", new_ratio);
-        if (new_ratio / self.resample_ratio_original >= 1.0 / self.max_relative_ratio)
-            && (new_ratio / self.resample_ratio_original <= self.max_relative_ratio)
-        {
-            if !ramp {
-                self.resample_ratio = new_ratio;
-            }
-            self.target_ratio = new_ratio;
-            self.update_lengths();
+        if self.relative_ratio_in_bounds(new_ratio / self.resample_ratio_original) {
+            self.apply_ratio(new_ratio, ramp);
             Ok(())
         } else {
             Err(ResampleError::RatioOutOfBounds {
@@ -624,7 +643,16 @@ where
 
     fn set_resample_ratio_relative(&mut self, rel_ratio: f64, ramp: bool) -> ResampleResult<()> {
         let new_ratio = self.resample_ratio_original * rel_ratio;
-        self.set_resample_ratio(new_ratio, ramp)
+        if self.relative_ratio_in_bounds(rel_ratio) {
+            self.apply_ratio(new_ratio, ramp);
+            Ok(())
+        } else {
+            Err(ResampleError::RatioOutOfBounds {
+                provided: new_ratio,
+                original: self.resample_ratio_original,
+                max_relative_ratio: self.max_relative_ratio,
+            })
+        }
     }
 }
 
@@ -832,6 +860,37 @@ mod tests {
         let mut resampler = Async::<f64>::new_sinc(ratio, 1.0, &params, 1024, 2, fixed).unwrap();
         resampler.set_chunk_size(600).unwrap();
         check_output!(resampler, f64);
+    }
+
+    // The exact relative bounds `1 / max` and `max` must be accepted. The pair below is chosen
+    // so that the old `(original * rel) / original` round-trip rounds the lower bound just outside
+    // the range and wrongly rejected it; checking the relative ratio directly must not.
+    #[test_log::test]
+    fn async_relative_ratio_exact_bounds() {
+        let params = basic_params();
+        let original_ratio = 44100.0 / 48000.0;
+        let max = 1.0161;
+        let mut resampler =
+            Async::<f64>::new_sinc(original_ratio, max, &params, 1024, 2, FixedAsync::Input)
+                .unwrap();
+
+        assert!(
+            resampler.set_resample_ratio_relative(max, false).is_ok(),
+            "exact upper bound must be accepted"
+        );
+        assert!(
+            resampler
+                .set_resample_ratio_relative(1.0 / max, false)
+                .is_ok(),
+            "exact lower bound must be accepted"
+        );
+        // Just outside the range must still be rejected.
+        assert!(resampler
+            .set_resample_ratio_relative(max * 1.0001, false)
+            .is_err());
+        assert!(resampler
+            .set_resample_ratio_relative(1.0 / max * 0.9999, false)
+            .is_err());
     }
 
     fn process_and_get_frame_counts(resampler: &mut Async<f64>) -> (usize, usize) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -119,7 +119,7 @@ impl error::Error for ResamplerConstructionError {}
 #[derive(Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub enum ResampleError {
-    /// Error raised when [Resampler::set_resample_ratio](crate::Resampler::set_resample_ratio)
+    /// Error raised when [Adjustable::set_resample_ratio](crate::Adjustable::set_resample_ratio)
     /// is called with a ratio outside the maximum range specified when
     /// the resampler was constructed.
     RatioOutOfBounds {
@@ -127,9 +127,6 @@ pub enum ResampleError {
         original: f64,
         max_relative_ratio: f64,
     },
-    /// Error raised when calling [Resampler::set_resample_ratio](crate::Resampler::set_resample_ratio)
-    /// on a synchronous resampler.
-    SyncNotAdjustable,
     /// Error raised when the number of channels in the input buffer doesn't match the value expected.
     WrongNumberOfInputChannels {
         expected: usize,
@@ -161,7 +158,6 @@ pub enum ResampleError {
         max: usize,
         requested: usize,
     },
-    ChunkSizeNotAdjustable,
 }
 
 impl fmt::Display for ResampleError {
@@ -174,9 +170,6 @@ impl fmt::Display for ResampleError {
             } => {
                 write!(f, "New resample ratio out of bounds. Provided ratio {}, original resample ratio {}, maximum relative ratio {}, allowed absolute range {} to {}",
                 provided, original, max_relative_ratio, original / max_relative_ratio, original * max_relative_ratio)
-            }
-            Self::SyncNotAdjustable { .. } => {
-                write!(f, "Not possible to adjust a synchronous resampler")
             }
             Self::WrongNumberOfInputChannels { expected, actual } => {
                 write!(
@@ -219,9 +212,6 @@ impl fmt::Display for ResampleError {
                     "Invalid chunk size {}, value must be non-zero and cannot exceed {}",
                     requested, max
                 )
-            }
-            Self::ChunkSizeNotAdjustable { .. } => {
-                write!(f, "This resampler does not support changing the chunk size")
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,43 +432,72 @@ where
     /// This gives how many frames any event in the input is delayed before it appears in the output.
     fn output_delay(&self) -> usize;
 
+    /// Get the current resample ratio, defined as output sample rate divided by input sample rate.
+    fn resample_ratio(&self) -> f64;
+
+    /// Reset the resampler state and clear all internal buffers.
+    fn reset(&mut self);
+
+    /// If this resampler can change its resample ratio, borrow it as an [Adjustable].
+    ///
+    /// Asynchronous resamplers return `Some`, synchronous resamplers return `None`. This lets
+    /// you recover the adjust-ratio capability from a `&mut dyn Resampler` without knowing the
+    /// concrete type:
+    ///
+    /// ```ignore
+    /// if let Some(adjustable) = resampler.as_adjustable() {
+    ///     adjustable.set_resample_ratio(new_ratio, true)?;
+    /// }
+    /// ```
+    fn as_adjustable(&mut self) -> Option<&mut dyn Adjustable<T>> {
+        None
+    }
+
+    /// If this resampler can change its chunk size, borrow it as a [Resizable], otherwise
+    /// return `None`.
+    fn as_resizable(&mut self) -> Option<&mut dyn Resizable<T>> {
+        None
+    }
+}
+
+/// A [Resampler] whose resample ratio can be changed after construction.
+///
+/// Implemented by the asynchronous resamplers. From a `&mut dyn Resampler` it can be recovered
+/// with [Resampler::as_adjustable].
+pub trait Adjustable<T>: Resampler<T>
+where
+    T: Sample,
+{
     /// Update the resample ratio.
     ///
-    /// For asynchronous resamplers, the ratio must be within
-    /// `original / maximum` to `original * maximum`, where the original and maximum are the
-    /// resampling ratios that were provided to the constructor.
-    /// Trying to set the ratio
-    /// outside these bounds will return [ResampleError::RatioOutOfBounds].
-    ///
-    /// For synchronous resamplers, this will always return [ResampleError::SyncNotAdjustable].
+    /// The ratio must be within `original / maximum` to `original * maximum`, where the original
+    /// and maximum are the resampling ratios that were provided to the constructor. Trying to set
+    /// the ratio outside these bounds will return [ResampleError::RatioOutOfBounds].
     ///
     /// If the argument `ramp` is set to true, the ratio will be ramped from the old to the new value
     /// during processing of the next chunk. This allows smooth transitions from one ratio to another.
     /// If `ramp` is false, the new ratio will be applied from the start of the next chunk.
     fn set_resample_ratio(&mut self, new_ratio: f64, ramp: bool) -> ResampleResult<()>;
 
-    /// Get the current resample ratio, defined as output sample rate divided by input sample rate.
-    fn resample_ratio(&self) -> f64;
-
     /// Update the resample ratio as a factor relative to the original one.
     ///
-    /// For asynchronous resamplers, the relative ratio must be within
-    /// `1 / maximum` to `maximum`, where `maximum` is the maximum
-    /// resampling ratio that was provided to the constructor.
-    /// Trying to set the ratio outside these bounds
-    /// will return [ResampleError::RatioOutOfBounds].
+    /// The relative ratio must be within `1 / maximum` to `maximum`, where `maximum` is the maximum
+    /// resampling ratio that was provided to the constructor. Trying to set the ratio outside these
+    /// bounds will return [ResampleError::RatioOutOfBounds].
     ///
     /// Ratios above 1.0 slow down the output and lower the pitch, while ratios
     /// below 1.0 speed up the output and raise the pitch.
-    ///
-    /// For synchronous resamplers, this will always return [ResampleError::SyncNotAdjustable].
     fn set_resample_ratio_relative(&mut self, rel_ratio: f64, ramp: bool) -> ResampleResult<()>;
+}
 
-    /// Reset the resampler state and clear all internal buffers.
-    fn reset(&mut self);
-
+/// A [Resampler] whose chunk size can be changed after construction.
+///
+/// From a `&mut dyn Resampler` it can be recovered with [Resampler::as_resizable].
+pub trait Resizable<T>: Resampler<T>
+where
+    T: Sample,
+{
     /// Change the chunk size for the resampler.
-    /// This is not supported by all resampler types.
     /// The value must be equal to or smaller than the chunk size value
     /// that the resampler was created with.
     /// [ResampleError::InvalidChunkSize] is returned if the value is zero or too large.
@@ -476,12 +505,7 @@ where
     /// The meaning of chunk size depends on the resampler,
     /// it refers to the input size for resamplers with fixed input size,
     /// and output size for resamplers with fixed output size.
-    ///
-    /// Resamplers that do not support changing the chunk size
-    /// return [ResampleError::ChunkSizeNotAdjustable].
-    fn set_chunk_size(&mut self, _chunksize: usize) -> ResampleResult<()> {
-        Err(ResampleError::ChunkSizeNotAdjustable)
-    }
+    fn set_chunk_size(&mut self, chunksize: usize) -> ResampleResult<()>;
 }
 
 pub(crate) fn validate_buffers<T>(
@@ -520,13 +544,13 @@ pub(crate) fn validate_buffers<T>(
 
 #[cfg(test)]
 pub mod tests {
-    #[cfg(feature = "fft_resampler")]
-    use crate::Fft;
     use crate::Resampler;
     use crate::{
         Async, FixedAsync, Indexing, ResampleError, SincInterpolationParameters,
         SincInterpolationType, WindowFunction,
     };
+    #[cfg(feature = "fft_resampler")]
+    use crate::{Fft, FixedSync};
     use audioadapter::Adapter;
     use audioadapter_buffers::direct::SequentialSliceOfVecs;
 
@@ -705,6 +729,31 @@ pub mod tests {
                     output2.read_sample(chan, frame)
                 );
             }
+        }
+    }
+
+    #[test_log::test]
+    fn capability_queries() {
+        // Async resamplers are adjustable and resizable.
+        let mut resampler = test_sinc_resampler();
+        resampler
+            .as_adjustable()
+            .expect("Async should be adjustable")
+            .set_resample_ratio_relative(1.05, false)
+            .unwrap();
+        assert!(resampler.as_resizable().is_some());
+
+        // The capability is reachable through a trait object too.
+        let mut boxed: Box<dyn Resampler<f64>> = Box::new(test_sinc_resampler());
+        assert!(boxed.as_adjustable().is_some());
+        assert!(boxed.as_resizable().is_some());
+
+        // Synchronous Fft resamplers are neither.
+        #[cfg(feature = "fft_resampler")]
+        {
+            let mut fft = Fft::<f64>::new(44100, 48000, 1024, 2, FixedSync::Both).unwrap();
+            assert!(fft.as_adjustable().is_none());
+            assert!(fft.as_resizable().is_none());
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,8 @@ where
     /// Reset the resampler state and clear all internal buffers.
     fn reset(&mut self);
 
-    /// If this resampler can change its resample ratio, borrow it as an [Adjustable].
+    /// If this resampler can change its resample ratio, borrow it as an [Adjustable],
+    /// otherwise return `None`.
     ///
     /// Asynchronous resamplers return `Some`, synchronous resamplers return `None`. This lets
     /// you recover the adjust-ratio capability from a `&mut dyn Resampler` without knowing the
@@ -449,14 +450,38 @@ where
     ///     adjustable.set_resample_ratio(new_ratio, true)?;
     /// }
     /// ```
-    fn as_adjustable(&mut self) -> Option<&mut dyn Adjustable<T>> {
-        None
+    ///
+    /// Any implementor of [Adjustable] must return `Some(self)` here, otherwise the capability
+    /// is invisible through a trait object. This method is intentionally required rather than
+    /// defaulted so that implementing [Adjustable] and advertising it cannot drift apart.
+    fn as_adjustable(&mut self) -> Option<&mut dyn Adjustable<T>>;
+
+    /// Returns `true` if this resampler is [Adjustable], meaning that
+    /// [as_adjustable](Resampler::as_adjustable) returns `Some`.
+    ///
+    /// Unlike [as_adjustable](Resampler::as_adjustable) this takes a shared reference, so the
+    /// capability can be queried through a `&dyn Resampler`. Implementors of [Adjustable] must
+    /// override this to return `true`.
+    fn is_adjustable(&self) -> bool {
+        false
     }
 
     /// If this resampler can change its chunk size, borrow it as a [Resizable], otherwise
     /// return `None`.
-    fn as_resizable(&mut self) -> Option<&mut dyn Resizable<T>> {
-        None
+    ///
+    /// Any implementor of [Resizable] must return `Some(self)` here, otherwise the capability
+    /// is invisible through a trait object. This method is intentionally required rather than
+    /// defaulted so that implementing [Resizable] and advertising it cannot drift apart.
+    fn as_resizable(&mut self) -> Option<&mut dyn Resizable<T>>;
+
+    /// Returns `true` if this resampler is [Resizable], meaning that
+    /// [as_resizable](Resampler::as_resizable) returns `Some`.
+    ///
+    /// Unlike [as_resizable](Resampler::as_resizable) this takes a shared reference, so the
+    /// capability can be queried through a `&dyn Resampler`. Implementors of [Resizable] must
+    /// override this to return `true`.
+    fn is_resizable(&self) -> bool {
+        false
     }
 }
 
@@ -736,6 +761,8 @@ pub mod tests {
     fn capability_queries() {
         // Async resamplers are adjustable and resizable.
         let mut resampler = test_sinc_resampler();
+        assert!(resampler.is_adjustable());
+        assert!(resampler.is_resizable());
         resampler
             .as_adjustable()
             .expect("Async should be adjustable")
@@ -743,8 +770,12 @@ pub mod tests {
             .unwrap();
         assert!(resampler.as_resizable().is_some());
 
-        // The capability is reachable through a trait object too.
+        // The capability is reachable through a trait object too, including through a shared
+        // reference via the `is_*` probes.
         let mut boxed: Box<dyn Resampler<f64>> = Box::new(test_sinc_resampler());
+        let shared: &dyn Resampler<f64> = boxed.as_ref();
+        assert!(shared.is_adjustable());
+        assert!(shared.is_resizable());
         assert!(boxed.as_adjustable().is_some());
         assert!(boxed.as_resizable().is_some());
 
@@ -752,6 +783,8 @@ pub mod tests {
         #[cfg(feature = "fft_resampler")]
         {
             let mut fft = Fft::<f64>::new(44100, 48000, 1024, 2, FixedSync::Both).unwrap();
+            assert!(!fft.is_adjustable());
+            assert!(!fft.is_resizable());
             assert!(fft.as_adjustable().is_none());
             assert!(fft.as_resizable().is_none());
         }

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -12,7 +12,7 @@ use audioadapter::{Adapter, AdapterMut};
 use crate::{get_offsets, get_partial_len, update_mask, Indexing};
 
 use crate::error::ResampleResult;
-use crate::{calculate_cutoff, validate_buffers, Resampler, Sample};
+use crate::{calculate_cutoff, validate_buffers, Adjustable, Resampler, Resizable, Sample};
 use realfft::{ComplexToReal, RealFftPlanner, RealToComplex};
 
 /// A helper for resampling a single chunk of data.
@@ -674,6 +674,14 @@ where
         self.channel_mask.iter_mut().for_each(|val| *val = true);
         self.saved_frames = 0;
         self.update_chunk_sizes();
+    }
+
+    fn as_adjustable(&mut self) -> Option<&mut dyn Adjustable<T>> {
+        None
+    }
+
+    fn as_resizable(&mut self) -> Option<&mut dyn Resizable<T>> {
+        None
     }
 }
 

--- a/src/synchro.rs
+++ b/src/synchro.rs
@@ -11,7 +11,7 @@ use audioadapter::{Adapter, AdapterMut};
 
 use crate::{get_offsets, get_partial_len, update_mask, Indexing};
 
-use crate::error::{ResampleError, ResampleResult};
+use crate::error::ResampleResult;
 use crate::{calculate_cutoff, validate_buffers, Resampler, Sample};
 use realfft::{ComplexToReal, RealFftPlanner, RealToComplex};
 
@@ -657,20 +657,8 @@ where
         self.fft_size_out / 2
     }
 
-    /// Update the resample ratio. This is not supported by this resampler and
-    /// always returns [ResampleError::SyncNotAdjustable].
-    fn set_resample_ratio(&mut self, _new_ratio: f64, _ramp: bool) -> ResampleResult<()> {
-        Err(ResampleError::SyncNotAdjustable)
-    }
-
     fn resample_ratio(&self) -> f64 {
         self.fft_size_out as f64 / self.fft_size_in as f64
-    }
-
-    /// Update the resample ratio relative to the original one. This is not
-    /// supported by this resampler and always returns [ResampleError::SyncNotAdjustable].
-    fn set_resample_ratio_relative(&mut self, _rel_ratio: f64, _ramp: bool) -> ResampleResult<()> {
-        Err(ResampleError::SyncNotAdjustable)
     }
 
     fn reset(&mut self) {


### PR DESCRIPTION
Builds on the `next4.0` branch. Moves the capability-specific methods off the single `Resampler` trait into dedicated traits, turning two runtime errors into compile-time capabilities while keeping `Resampler` as the universal trait for mixed `Box<dyn Resampler>` collections.

## Changes
- New `Adjustable<T>: Resampler<T>` — `set_resample_ratio`, `set_resample_ratio_relative`
- New `Resizable<T>: Resampler<T>` — `set_chunk_size`
- `Resampler::as_adjustable()` / `as_resizable()` recover the capability from a trait object (default `None`; `Async` returns `Some(self)`, `Fft` does not)
- Removed the now-unreachable `ResampleError::SyncNotAdjustable` and `ChunkSizeNotAdjustable` variants